### PR TITLE
[Central] updated documentation for block 8 release

### DIFF
--- a/odk1-src/central-forms.rst
+++ b/odk1-src/central-forms.rst
@@ -5,14 +5,19 @@ Managing Forms in Central
 
 Forms are at the heart of Open Data Kit. Once fetched onto a mobile device from ODK Central, they define the questions, validation, and logic to be presented during data collection. They also serve to organize the data coming back from mobile devices.
 
-In ODK Central, there are four important steps to understand when managing a data collection project:
+.. _central-forms-forms:
 
-1. **Form design** is where you define the form itself, laying out many details like the questions and acceptable responses. ODK Central itself does not help with form design. Instead, please take a look at the many :doc:`available tools <form-tools>` and the :doc:`introduction to form design <form-design-intro>` for help creating your form.
-2. **Form upload** is done after you have a working form design. Here you log into ODK Central and upload your new form so that Central knows that it exists. Once you do this, it will become available to any mobile device connected to the project for download and submission upload.
+Forms in ODK Central
+--------------------
+
+In ODK Central, there are four important tasks you'll perform while managing a data collection project:
+
+1. **Form drafting** is where you design the Form itself, laying out many details like the questions and acceptable responses. ODK Central itself does not help with form design: instead, please take a look at the many :doc:`available tools <form-tools>` and the :doc:`introduction to form design <form-design-intro>` for help creating your form. Central does, however, help with **testing** your design, with Form Drafts. When you first upload your Form, it will be a Draft to which you can connect a mobile device and submit test data. If you are not satisfied with the Form, you can adjust the design and upload a new version in place of the old Draft. Once you are satisfied, you can **Publish** the Form to make it ready for use.
+2. **Form lifecycle** settings allow you to control who can access and submit to particular Forms. These tools can help manage user permissions, but they can also help phase out outdated Forms as they come to the end of their life. You can control these using the :ref:`Form Access <central-projects-form-access>` tab on the Project.
 3. **Data extraction and analysis** can occur either at the end of the project, or continually as the project runs. Either way, ODK Central provides several different methods for extracting and analyzing your submission data. This is covered in the :doc:`Form Submissions <central-submissions>` article.
-4. **Form lifecycle** tools let you manage the lifecycle of your data collection project: ongoing projects can be left alone to stay open, but many projects need a way to wrap things up. ODK Central provides tools to help control, for example, when workers using ODK Collect are allowed to download each form's definition, or separately to upload submissions to each form.
+4. **Form updates** allow you to make changes to a Form while it is already in use. Central allows you to create a new Draft of any Form at any time. As with initial Form creation, this Draft allows you to test your changes in a staging environment where it will not affect the live Form or its data. When you are satisfied with the Draft, you can again **Publish** it, and it will replace the live version.
 
-For more information about how to accomplish each of these tasks, please read on.
+Drafting and version updates are new as of Central version 0.8. We will cover all of these topics in the sections below.
 
 .. _central-forms-upload:
 
@@ -39,34 +44,53 @@ You can either click on the :guilabel:`choose one` button to browse for your :fi
    - You may see a message that reads **A resource already exists with xmlFormId value(s) of xyz.** If you do, there already exists a form within this project with the same unique designation. If you are using XLSForm, try changing the name of the file or the ``form_id`` in the settings sheet. If you designed the form by hand, please check the ``id="…"`` attribute immediately inside the ``<instance>`` tag.
    - You may see a message that says **A form previously existed which had the same formId and version as the one you are attempting to create now. To prevent confusion, please change one or both and try creating the form again.** This means there once was a form within this project that has since been deleted that has exactly the same formId (see the previous bullet point) *and* version designation as the one you are now trying to upload. Central won't accept the new form, because this conflict could cause confusion with mobile devices that still have the old form sitting around. To upload this form, change either the formId (again, see the previous bullet point) or `update the version <https://opendatakit.github.io/xforms-spec/#primary-instance>`_ and try again.
 
-Once the form is successfully uploaded, you will be taken to the Form Overview page.
+Once the form is successfully uploaded, you will be taken to the Form Draft page. It will not be accessible to data collection clients until you publish the Draft, which we will cover in the following section.
+
+.. _central-forms-draft:
+
+Working With Form Drafts
+------------------------
+
+Form Drafts, available as of Central version 0.8, provide a way to safely and easily verify the design of your Form before you make it available for use. Drafts are accessible only to privileged Project staff. Each Form Draft has a unique access token which allows configured data collection clients to submit test submissions to the Draft. These test submissions disappear automatically when the Draft is published. Once a Draft is published, it is available for use according to the access rules you have specified in the :ref:`Form Access <central-projects-form-access>` tab on the Project.
+
+   .. image:: /img/central-forms/draft-overview.png
+
+The **Draft Status** page gives insight into the current status of your Draft, and provides controls for managing it.
+
+On the left, you will find the Draft Checklist, which suggests the steps you might take before publishing your Draft. On the right are details about the currently uploaded Draft version of the Form, including its current version string, and actions you may take on the Draft:
+
+ - The :guilabel:`Upload new definition` button will allow you to upload a new Form definition, which will replace the current Draft version. When this happens, all test submissions will be erased. If you have uploaded Media Files, Central will attempt to preserve any that match the new definition.
+ - The :guilabel:`Publish Draft` button will publish the Draft, making it available for use according to the access rules you have specified on the :ref:`Form Access <central-projects-form-access>` tab on the Project. Any test submissions you have made will be erased.
+ - The :guilabel:`Abandon Draft` button will delete the Draft. When there is not yet a published version, this will delete the entire Form. If the Form has been published, only the Draft will be deleted.
 
 .. tip::
-  When a form is first created, none of the existing App Users on the project will be able to access it for download or submission. Once you are ready to allow App Users to access the form, use the Project :ref:`Form Access <central-projects-form-access>` tab.
+  When a form is first created, none of the existing App Users on the project will be able to access it for download or submission, even once the Form is published. Once you are ready to allow App Users to access the form, use the Project :ref:`Form Access <central-projects-form-access>` tab.
 
-.. _central-forms-checklist:
+.. _central-forms-draft-tabs:
 
-The Form Overview page
-----------------------
+Form Draft Tabs
+~~~~~~~~~~~~~~~
 
-Here, you can get a brief summary of the status of your form, and recommended next steps. You are automatically taken here when you upload a new form or click on the form name in the Form listing page. You can also get back here from other form-related pages by clicking the :menuselection:`--> Overview` tab below the name of the form.
+When you first create a new Form, the navigation tabs on the left will not be accessible. They pertain to the published version of the Form, and will become available once you publish your Draft. The tabs on the right, within the gray Draft section, relate to the Draft.
 
-   .. image:: /img/central-forms/checklist.png
+If your Draft requires Media Files, there will be a checklist step asking you to upload them, and a Media Files tab at the top of the page. See the next section :ref:`Forms With Attachments <central-forms-attachments>` for more information about uploading and managing attachments.
 
-The documentation on this page is a more detailed introductory explanation of form management in ODK Central, but the checklist you find on the Overview page is tailored to the current status of your form and your project and is a great place to look when you aren't sure what to do next.
+The :guilabel:`Testing` Draft tab shows test submissions that have been made to the Draft, and instructions for doing so:
 
-In the future, look forward to seeing even more useful information at-a-glance on this page.
+   .. image:: /img/central-forms/testing.png
+
+At the top of the page are instructions and a QR Code which will configure a mobile device to submit to the Draft Form. For help configuring a mobile device, please see :doc:`importing settings into Collect <collect-import-export>`. The table below these instructions contains any test submissions that have been made to the current Draft. For help with this table or exporting test data, please see :doc:`Form Submissions in Central <central-submissions>`.
 
 .. _central-forms-attachments:
 
 Forms With Attachments
 ----------------------
 
-If your uploaded form references any external files (images, audio, or video included as part of your question prompts, or data lookup files used to populate selection lists), Central will see this and open up some additional displays and controls you will need to provide those external files:
+If your Form Draft references any external files (images, audio, or video included as part of your question prompts, or data lookup files used to populate selection lists), Central will see this and open up some additional displays and controls you will need to provide those external files:
 
    .. image:: /img/central-forms/attachments-overview.png
 
-If you see this extra **Upload Form Media Files** checklist step and **Media Files** tab at the top of your form overview, then Central believes you need to upload some files associated with this form. If the checklist step has been checked off, then you've already completed this task: great work! Otherwise, click on the :menuselection:`--> Media Files` tab at the top to see what files you'll need to provide.
+If you see this extra **Upload Form Media Files** checklist step and **Media Files** tab at the top of your Form Draft checklist, then Central believes you need to upload some files associated with this form. If the checklist step has been checked off, then you've already completed this task: great work! Otherwise, click on the :menuselection:`--> Media Files` tab at the top to see what files you'll need to provide.
 
    .. image:: /img/central-forms/attachments-listing.png
 
@@ -75,6 +99,8 @@ This form design references three files that we'll need to provide, one of which
 .. admonition:: On File Types and Contents
 
    While Central will detect the type of file the form design expects, and will verify that the name of any uploaded file matches one that is expected, Central will *not* double-check the *type* of the file, nor the *contents* of the file for you. So, just because Central accepts your file does not necessarily mean that it will work correctly.
+
+Once you publish a Draft, you will not be able to modify the Attachments associated with it without creating a new Draft.
 
 .. _central-forms-attachments-multi:
 
@@ -93,6 +119,19 @@ Uploading One Attachment
    .. image:: /img/central-forms/attachments-single.png
 
 If you drag a single file onto the table, you'll have the option of which table row you'd like to upload that file into. This way, if the file isn't named exactly what Central expects, you can still upload a file into that slot without having to rename it on your own computer. But if the file does have the appropriate name, you can drop it somewhere other than a specific slot (for example, just below or just above the table) to have Central match it up with the correct slot automatically.
+
+.. _central-forms-checklist:
+
+The Form Overview page
+----------------------
+
+Here, you can get a brief summary of the status of your form, and recommended next steps. You are automatically taken here when you publish a Form Draft or click on the form name in the Form listing page. You can also get back here from other form-related pages by clicking the :menuselection:`--> Overview` tab below the name of the form.
+
+   .. image:: /img/central-forms/checklist.png
+
+The documentation on this page is a more detailed introductory explanation of form management in ODK Central, but the checklist you find on the Overview page is tailored to the current status of your form and your project and is a great place to look when you aren't sure what to do next.
+
+In the future, look forward to seeing even more useful information at-a-glance on this page.
 
 .. _central-forms-submissions:
 
@@ -121,6 +160,40 @@ As you can see, you can use the **Closing** state to prevent further distributio
 To set the form lifecycle stage, go to the :ref:`Form Access <central-projects-form-access>` tab for the Project, under the name of the Project at the top of the page. You may have to navigate back out of the Form first by clicking on the :guilabel:`Back to Project Overview` link at the top of the page. Here, you will find the three possible stages in a dropdown for each Form on the left side of the page. Select the ones you want for each Form, then click :guilabel:`Save` at the top-right to save the changes.
 
 You can find more information about the Form Access page :ref:`here <central-projects-form-access>`.
+
+.. _central-forms-updates:
+
+Form Updates
+------------
+
+As of Central version 0.8, it is possible to update a published Form with a new design definition, or new Media Files, and to test these changes before they are applied to the Form in use.
+
+There is one primary restriction Central enforces on updated design definitions: once defined in a published Form version, each field Data Name (in technical terms, the Instance XPath) cannot change its Data Type. Unused fields may be removed, and new fields may be added, but if any field reuses a previously existing Data Name, it must have the same Type as it did before. If you run into an error with this restriction, the easiest solution is usually to rename the changed field to a new name.
+
+To begin the process of updating a published Form, click on the :guilabel:`Create a new Draft` button in the Draft navigation on the Form:
+
+   .. image:: /img/central-forms/update-form.png
+
+Initially, the new Draft will have the same design definition as the published Form. If you only want to update attachment Media Files, this means you don't have to bother uploading a definition at all: you can go straight to the :guilabel:`Media Files` tab and :ref:`upload the changed files <central-forms-attachments>`.
+
+You can replace the Draft definition, Media Files, and make test submissions as with the :ref:`initial Form Draft <central-forms-draft>` before the Form was first published. Test submissions will not interfere with published Form submissions.
+
+Once you are satisfied that your updated Form is ready to be published for immediate use, you can click on the :guilabel:`Publish Draft` button on the Draft Status tab.
+
+.. admonition:: Form Version naming
+
+  If you did not change the design definition, or your updated design definition did not change the ``version`` of the Form, Central will not be able to publish the Form as-is. This is because the ``version`` must change in order for data collection clients to understand that they should update. You can upload a new design definition with a changed ``version``, or else Central will offer to change it in-place for you.
+
+.. _central-forms-versions:
+
+Older Form Versions
+-------------------
+
+If you have published multiple version of a Form, you can each of them under the :guilabel:`Versions` tab.
+
+   .. image:: /img/central-forms/versions.png
+
+Each published version of the Form will be listed, along with actions to download the design definition of each Form. In future versions of Central, the Media File attachments associated with each version of the Form will be downloadable as well.
 
 .. _central-forms-delete:
 

--- a/odk1-src/central-forms.rst
+++ b/odk1-src/central-forms.rst
@@ -17,7 +17,7 @@ In ODK Central, there are four important tasks you'll perform while managing a d
 3. **Data extraction and analysis** can occur either at the end of the project, or continually as the project runs. Either way, ODK Central provides several different methods for extracting and analyzing your submission data. This is covered in the :doc:`Form Submissions <central-submissions>` article.
 4. **Form updates** allow you to make changes to a Form while it is already in use. Central allows you to create a new Draft of any Form at any time. As with initial Form creation, this Draft allows you to test your changes in a staging environment where it will not affect the live Form or its data. When you are satisfied with the Draft, you can again **Publish** it, and it will replace the live version.
 
-Drafting and version updates are new as of Central version 0.8. We will cover all of these topics in the sections below.
+Drafting and version updates are new as of Central 0.8. We will cover all of these topics in the sections below.
 
 .. _central-forms-upload:
 
@@ -48,10 +48,10 @@ Once the form is successfully uploaded, you will be taken to the Form Draft page
 
 .. _central-forms-draft:
 
-Working With Form Drafts
-------------------------
+Form Drafts
+-----------
 
-Form Drafts, available as of Central version 0.8, provide a way to safely and easily verify the design of your Form before you make it available for use. Drafts are accessible only to privileged Project staff. Each Form Draft has a unique access token which allows configured data collection clients to submit test submissions to the Draft. These test submissions disappear automatically when the Draft is published. Once a Draft is published, it is available for use according to the access rules you have specified in the :ref:`Form Access <central-projects-form-access>` tab on the Project.
+Form Drafts, available as of Central 0.8, provide a way to safely and easily verify the design of your Form before you make it available for use. Drafts are accessible only to privileged Project staff. Each Form Draft has a unique access token which allows configured data collection clients to submit test submissions to the Draft. These test submissions disappear automatically when the Draft is published. Once a Draft is published, it is available for use according to the access rules you have specified in the :ref:`Form Access <central-projects-form-access>` tab on the Project.
 
    .. image:: /img/central-forms/draft-overview.png
 
@@ -166,7 +166,7 @@ You can find more information about the Form Access page :ref:`here <central-pro
 Form Updates
 ------------
 
-As of Central version 0.8, it is possible to update a published Form with a new design definition, or new Media Files, and to test these changes before they are applied to the Form in use.
+As of Central 0.8, it is possible to update a published Form with a new design definition, or new Media Files, and to test these changes before they are applied to the Form in use.
 
 There is one primary restriction Central enforces on updated design definitions: once defined in a published Form version, each field Data Name (in technical terms, the Instance XPath) cannot change its Data Type. Unused fields may be removed, and new fields may be added, but if any field reuses a previously existing Data Name, it must have the same Type as it did before. If you run into an error with this restriction, the easiest solution is usually to rename the changed field to a new name.
 

--- a/odk1-src/central-forms.rst
+++ b/odk1-src/central-forms.rst
@@ -197,7 +197,7 @@ Once the Draft has been published, it becomes the version in use and there will 
 Accessing Older Form Versions
 -----------------------------
 
-If you have published multiple version of a Form, you can each of them under the :guilabel:`Versions` tab.
+If you have published multiple version of a Form, you can see each of them under the :guilabel:`Versions` tab.
 
    .. image:: /img/central-forms/versions.png
 

--- a/odk1-src/central-forms.rst
+++ b/odk1-src/central-forms.rst
@@ -48,10 +48,15 @@ Once the form is successfully uploaded, you will be taken to the Form Draft page
 
 .. _central-forms-draft:
 
-Form Drafts
------------
+Understanding Form Drafts
+-------------------------
 
 Form Drafts, available as of Central 0.8, provide a way to safely and easily verify the design of your Form before you make it available for use. Drafts are accessible only to privileged Project staff. Each Form Draft has a unique access token which allows configured data collection clients to submit test submissions to the Draft. These test submissions disappear automatically when the Draft is published. Once a Draft is published, it is available for use according to the access rules you have specified in the :ref:`Form Access <central-projects-form-access>` tab on the Project.
+
+.. _central-forms-draft-tabs:
+
+Working with Form Drafts
+~~~~~~~~~~~~~~~~~~~~~~~~
 
    .. image:: /img/central-forms/draft-overview.png
 
@@ -65,11 +70,6 @@ On the left, you will find the Draft Checklist, which suggests the steps you mig
 
 .. tip::
   When a form is first created, none of the existing App Users on the project will be able to access it for download or submission, even once the Form is published. Once you are ready to allow App Users to access the form, use the Project :ref:`Form Access <central-projects-form-access>` tab.
-
-.. _central-forms-draft-tabs:
-
-Form Draft Tabs
-~~~~~~~~~~~~~~~
 
 When you first create a new Form, the navigation tabs on the left will not be accessible. They pertain to the published version of the Form, and will become available once you publish your Draft. The tabs on the right, within the gray Draft section, relate to the Draft.
 
@@ -163,18 +163,18 @@ You can find more information about the Form Access page :ref:`here <central-pro
 
 .. _central-forms-updates:
 
-Form Updates
-------------
+Updating Forms to a New Version
+-------------------------------
 
-As of Central 0.8, it is possible to update a published Form with a new design definition, or new Media Files, and to test these changes before they are applied to the Form in use.
+As of Central 0.8, it is possible to update a published Form with a new definition, or new Media Files, and to test these changes before they are applied to the Form in use.
 
-There is one primary restriction Central enforces on updated design definitions: once defined in a published Form version, each field Data Name (in technical terms, the Instance XPath) cannot change its Data Type. Unused fields may be removed, and new fields may be added, but if any field reuses a previously existing Data Name, it must have the same Type as it did before. If you run into an error with this restriction, the easiest solution is usually to rename the changed field to a new name.
+There is one primary restriction Central enforces on updated definitions: once defined in a published Form version, each field Data Name (in technical terms, the Instance XPath) cannot change its Data Type. Unused fields may be removed, and new fields may be added, but if any field reuses a previously existing Data Name, it must have the same Type as it did before. If you run into an error with this restriction, the easiest solution is usually to rename the changed field to a new name.
 
 To begin the process of updating a published Form, click on the :guilabel:`Create a new Draft` button in the Draft navigation on the Form:
 
    .. image:: /img/central-forms/update-form.png
 
-Initially, the new Draft will have the same design definition as the published Form. If you only want to update attachment Media Files, this means you don't have to bother uploading a definition at all: you can go straight to the :guilabel:`Media Files` tab and :ref:`upload the changed files <central-forms-attachments>`.
+Initially, the new Draft will have the same definition as the published Form. If you only want to update attachment Media Files, this means you don't have to bother uploading a definition at all: you can go straight to the :guilabel:`Media Files` tab and :ref:`upload the changed files <central-forms-attachments>`.
 
 You can replace the Draft definition, Media Files, and make test submissions as with the :ref:`initial Form Draft <central-forms-draft>` before the Form was first published. Test submissions will not interfere with published Form submissions.
 
@@ -182,18 +182,26 @@ Once you are satisfied that your updated Form is ready to be published for immed
 
 .. admonition:: Form Version naming
 
-  If you did not change the design definition, or your updated design definition did not change the ``version`` of the Form, Central will not be able to publish the Form as-is. This is because the ``version`` must change in order for data collection clients to understand that they should update. You can upload a new design definition with a changed ``version``, or else Central will offer to change it in-place for you.
+  If you did not change the definition, or your updated definition did not change the ``version`` of the Form, Central will not be able to publish the Form as-is. This is because the ``version`` must change in order for data collection clients to understand that they should update. You can upload a new definition with a changed ``version``, or else Central will offer to change it in-place for you.
+
+Once the Draft has been published, it becomes the version in use and there will no longer be a Draft associated with the Form.
+
+.. admonition:: What happens to my submissions?
+
+  When a new Form version is published in place of an old one, all the previous submissions continue to exist, and will export along with all your data over Zip download or OData. However, only the current Form definition will be used in that export: if, for example, you have deleted a field that used to exist, that field will not appear in the export.
+
+  Draft testing submissions will never export with your final data, and only exist as long as the Draft does. If you delete, publish, or replace your current Draft, all test submissions will be cleared away.
 
 .. _central-forms-versions:
 
-Older Form Versions
--------------------
+Accessing Older Form Versions
+-----------------------------
 
 If you have published multiple version of a Form, you can each of them under the :guilabel:`Versions` tab.
 
    .. image:: /img/central-forms/versions.png
 
-Each published version of the Form will be listed, along with actions to download the design definition of each Form. In future versions of Central, the Media File attachments associated with each version of the Form will be downloadable as well.
+Each published version of the Form will be listed, along with actions to download the definition of each Form. In future versions of Central, the Media File attachments associated with each version of the Form will be downloadable as well.
 
 .. _central-forms-delete:
 

--- a/odk1-src/central-install-digital-ocean.rst
+++ b/odk1-src/central-install-digital-ocean.rst
@@ -137,6 +137,19 @@ Once you do see it working, you'll want to set up your first Administrator accou
 
 Once you have one account, you do not have to go through this process again for future accounts: you can log into the website with your new account, and directly create new users that way.
 
+.. _central-install-digital-ocean-monitoring:
+
+Setting Up Monitoring
+---------------------
+
+The last thing you will want to do is to set up server monitoring. Alerts and monitoring are important because they can inform you of problems with your server before they affect your data collection project.
+
+You can find instructions for setting up alerts in the `DigitalOcean Documentation  <https://www.digitalocean.com/docs/monitoring/how-to/set-up-alerts/>`_.
+
+We strongly recommend creating an alert for Disk Utilization. A threshold of 90% is usually reasonable. By far the most common operations issue we see is servers running out of disk space as large photo files pile up. If your server runs entirely out of disk space, it can crash and become unresponsive. It is best to upgrade your storage plan before this happens.
+
+If you are familiar with server operations, you may wish to set up some other alerts: CPU usage and Memory Utilization are the most interesting remaining metrics. However, these are not as important or easily understandable as the Disk Utilization alert, so you may skip this if you're not sure what to do here.
+
 You're done! Congratulations. In the future, you may wish to consult the :doc:`central-upgrade` guide, but for now you may begin using ODK Central. The :doc:`central-using` sections can help you with your next steps if you aren't sure how to proceed.
 
 .. _central-install-digital-ocean-advanced:

--- a/odk1-src/central-install-digital-ocean.rst
+++ b/odk1-src/central-install-digital-ocean.rst
@@ -146,7 +146,7 @@ The last thing you will want to do is to set up server monitoring. Alerts and mo
 
 You can find instructions for setting up alerts in the `DigitalOcean Documentation  <https://www.digitalocean.com/docs/monitoring/how-to/set-up-alerts/>`_.
 
-We strongly recommend creating an alert for Disk Utilization. A threshold of 90% is usually reasonable. By far the most common operations issue we see is servers running out of disk space as large photo files pile up. If your server runs entirely out of disk space, it can crash and become unresponsive. It is best to upgrade your storage plan before this happens.
+We strongly recommend creating an alert for Disk Utilization. A threshold of 90% is usually reasonable. By far the most common operations issue we see is servers running out of disk space as large media attachments pile up. If your server runs entirely out of disk space, it can crash and become unresponsive. It is best to upgrade your storage plan before this happens.
 
 If you are familiar with server operations, you may wish to set up some other alerts: CPU usage and Memory Utilization are the most interesting remaining metrics. However, these are not as important or easily understandable as the Disk Utilization alert, so you may skip this if you're not sure what to do here.
 

--- a/odk1-src/central-intro.rst
+++ b/odk1-src/central-intro.rst
@@ -19,6 +19,8 @@ We have a lot of exciting ideas for the future of Central, and we look forward t
  - Projects to organize users, permissions, and forms
  - Form and submission upload and management
 
+   - With support for form version updates
+   - With drafts and testing on initial creation, and on version updates
    - With form and submission multimedia or data attachments
    - With a table preview of submission data
    - Encrypted forms (self-supplied or project managed keys)

--- a/odk1-src/central-projects.rst
+++ b/odk1-src/central-projects.rst
@@ -146,7 +146,10 @@ We place these access controls for all Forms in a single place, on the Form Acce
 
    .. image:: /img/central-projects/access.png
 
-On the left side of the Form Access page, you will find a list of all the Forms in the Project, along with a dropdown selection to set the lifecycle state for each one. Along the top, you will see all active App Users in the Project. At each row/column intersection, there is a checkbox that governs whether each App User is allowed access to each Form.
+On the left side of the Form Access page, you will find a list of all the Forms in the Project, along with a dropdown selection to set the Form Lifecycle state for each one. Along the top, you will see all active App Users in the Project. At each row/column intersection, there is a checkbox that governs whether each App User is allowed access to each Form.
+
+.. tip::
+  You may see a pencil icon next to the Lifecycle state dropdown on some Forms. This means that those Forms are currently Drafts, with no published version. They will not be visible to data collection clients no matter the Lifecycle state setting, or the checkboxes on this page. Once a Draft Form is published, then the settings on this page will immediately take effect.
 
 If you are having trouble recalling what each Form State means, the :guilabel:`?` icon in the header will give you a quick recap:
 

--- a/odk1-src/img/central-forms/attachments-listing.png
+++ b/odk1-src/img/central-forms/attachments-listing.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:38ddcf75733e83ea966eb1cad351e57644fa7889ab58cc80df1bbd072f006dcd
-size 77564
+oid sha256:a7101e9b3db16ec02354c15d521d9f6bcfc776f35de46d750a1946b578408cf5
+size 92445

--- a/odk1-src/img/central-forms/attachments-multi.png
+++ b/odk1-src/img/central-forms/attachments-multi.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:532b376e49da9874d3563a3ef96a521ea3fefda650581ae1b5f200996981697a
-size 318798
+oid sha256:a606f95b27d163aa5acdac32e97e25ed5cbfbd7acf2d6475e2344a5180a7371b
+size 303349

--- a/odk1-src/img/central-forms/attachments-overview.png
+++ b/odk1-src/img/central-forms/attachments-overview.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c85615ee51f12640727c8bb41a92b885d2d05dc3e817b45f805e405635a85da9
-size 178978
+oid sha256:438a7ca83d010c04655ff13dd95bcb3ed2cca45f0167e7a52f2761041607d5d8
+size 186895

--- a/odk1-src/img/central-forms/attachments-single.png
+++ b/odk1-src/img/central-forms/attachments-single.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:94fe200ca28acb2a917d3e658f00d30011dcac17d05ccca15d704fa84c29030d
-size 296246
+oid sha256:6e73c630b8a42896117650fc3d7788f2905884c4327a1fc1ba9a8f73f7e3d0d1
+size 277876

--- a/odk1-src/img/central-forms/checklist.png
+++ b/odk1-src/img/central-forms/checklist.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fb1e925662b5e82aadd823b223bb00fb63e2ab11eb9d4fa28c946cbde4b4e466
-size 163138
+oid sha256:46c2ce42574136d09808ccf0eb993ce329bdf2aef4bc5e8331e4f1137ff4aadb
+size 336331

--- a/odk1-src/img/central-forms/draft-overview.png
+++ b/odk1-src/img/central-forms/draft-overview.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b33d1fc92e4deb1bf1f4f1a8fdd1ac9088fc3216c5fb21d88db8aca97dd884d
+size 204845

--- a/odk1-src/img/central-forms/testing.png
+++ b/odk1-src/img/central-forms/testing.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5654619e07f47d318b10914b6a00fbf4b7c6f01024a0fb6f5e4e852fda990d3e
+size 179479

--- a/odk1-src/img/central-forms/update-form.png
+++ b/odk1-src/img/central-forms/update-form.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:285623fb88dedadea5f7a0f4e5d186022d9b3580ae4788cbba1beb21fe8a1dba
+size 79349

--- a/odk1-src/img/central-forms/versions.png
+++ b/odk1-src/img/central-forms/versions.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d56ef7cdebfcf8448704e161c46a42544fa1d32444c3573f85b4c09152543b18
+size 73942


### PR DESCRIPTION
closes #1212

adds documentation on form draft/versions/testing
adds documentation on enabling digital ocean monitoring for disk utilization