### PR TITLE
Smaller and white logo

### DIFF
--- a/odk1-src/_static/css/custom.css
+++ b/odk1-src/_static/css/custom.css
@@ -6,6 +6,10 @@
     font-family: Georgia, "Times New Roman", serif;
 } 
 
+.wy-side-nav-search>a img.logo {
+    height: 45px;
+}
+
 /* Styling for rst roles and directives starts */
 
 /* code-sample styling PR #90 */ 

--- a/shared-src/_static/img/odk-logo-wide.png
+++ b/shared-src/_static/img/odk-logo-wide.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:42f1b2b35fee619a946eef23412a5dad1a7335add1bdf67a2844b39f278aace5
-size 64624
+oid sha256:35bcf56aebc3d291dfadf4077fa8347b826618085ec64fee46cf854f58da468f
+size 64350


### PR DESCRIPTION
<img width="815" alt="Screen Shot 2020-04-23 at 3 48 58 PM" src="https://user-images.githubusercontent.com/32369/80156939-fa97a280-8579-11ea-8437-e051de695990.png">

Tried to match the size to the forum logo. I eyeballed it.

Changed the docs color to white to match the default look of Sphinx. 