### PR TITLE
Fix for outdated key values in the list for all QR code settings

### DIFF
--- a/odk1-src/collect-import-export.rst
+++ b/odk1-src/collect-import-export.rst
@@ -117,7 +117,7 @@ Here are the keys for all settings and the set of values they can take:
     "general" : {
 
       // Server
-      "protocol": {"odk_default", "google_sheets", "other"},
+      "protocol": {"odk_default", "google_sheets", "other_protocol"},
       "server_url": String,
       "username": String,
       "password": String,
@@ -152,7 +152,7 @@ Here are the keys for all settings and the set of values they can take:
       "constraint_behavior": {"on_swipe", "on_finalize"},
       "high_resolution": Boolean,
       "image_size": {"original", "small", "very_small", "medium", "large"},
-      "guidance_hint": {"no", "yes", "collapsed"},
+      "guidance_hint": {"no", "yes", "yes_collapsed"},
       "instance_sync": Boolean,
       "analytics": Boolean,
       "metadata_username": String,


### PR DESCRIPTION
At:
https://forum.getodk.org/t/qr-code-contains-no-information-about-google-map-style/28289/2

#### What is included in this PR?
I've noticed that the [ODK documentation](https://docs.getodk.org/collect-import-export/#list-of-keys-for-all-settings) is outdated for some key values. I'm changing some values I've found decoding de configuration QR code generated by ODK Collect.

>// Server
>"protocol": {"odk_default", "google_sheets", "~~other~~"} ---> must be substituted by **other_protocol**
>
>// Form management
>"guidance_hint": {"no", "yes", "~~collapsed~~"} ---> must be substituted by **yes_collapsed**

<!-- Answer any that apply and delete the others. -->
#### What is left to be done in the addressed issue?
I haven't checked other values, so there may be other cases. I'll let you know if I find anything else.
