### PR TITLE
Make Central the recommended server across the documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ tmp*
 # pyenv
 .python-version
 
+# venv recommended environment
+odkenv/
+
 # literate programming
 style-checks.py
 extra.py

--- a/odk1-src/aggregate-admin.rst
+++ b/odk1-src/aggregate-admin.rst
@@ -1,6 +1,9 @@
 Administering Aggregate
 ===========================
 
+.. warning::
+  Aggregate is no longer actively developed. Please use :doc:`ODK Central <central-intro>` instead.
+
 Click the :guilabel:`Log In` link in the upper right corner of the screen to be presented with the Log onto Aggregate screen. Choose the :guilabel:`Sign in with Aggregate password` button and enter the super-user username you specified within the installer. The initial password for this account is `aggregate`. When you log in, :guilabel:`Site Admin` will be visible to you.
 
 .. tip::

--- a/odk1-src/aggregate-app-engine-legacy.rst
+++ b/odk1-src/aggregate-app-engine-legacy.rst
@@ -6,6 +6,9 @@ Google App Engine Support (Legacy)
 ==================================
 
 .. warning::
+  Aggregate is no longer actively developed. Please use :doc:`ODK Central <central-intro>` instead.
+
+.. warning::
 
   In February 2019, ODK Aggregate v2.x was released with support for Google App Engine removed. This page gathers all the information previously available about Google App Engine for Aggregate v1.x. See `why we are removing App Engine support <https://forum.getodk.org/t/upcoming-changes-to-aggregate/17582>`_ for more information.
 

--- a/odk1-src/aggregate-app-engine.rst
+++ b/odk1-src/aggregate-app-engine.rst
@@ -4,6 +4,9 @@ Installing Aggregate on Google App Engine
 =========================================
 
 .. warning::
+  Aggregate is no longer actively developed. Please use :doc:`ODK Central <central-intro>` instead.
+
+.. warning::
 
   This document only applies ODK Aggregate v1.x. See `why we are removing App Engine support <https://forum.getodk.org/t/upcoming-changes-to-aggregate/17582>`_ for more information.
 

--- a/odk1-src/aggregate-aws.rst
+++ b/odk1-src/aggregate-aws.rst
@@ -8,6 +8,9 @@ Installing on Amazon Web Services
 =================================
 
 .. warning::
+  Aggregate is no longer actively developed. Please use :doc:`ODK Central <central-intro>` instead.
+
+.. warning::
 
   To use this setup, you must able to link a domain name to the machine's IP address. If you don’t own a domain, services such as `FreeDNS <https://freedns.afraid.org>`_ offer free sub-domains under a range of domains.
 

--- a/odk1-src/aggregate-azure.rst
+++ b/odk1-src/aggregate-azure.rst
@@ -7,6 +7,9 @@ Installing on Microsoft Azure
 =============================
 
 .. warning::
+  Aggregate is no longer actively developed. Please use :doc:`ODK Central <central-intro>` instead.
+
+.. warning::
 
   To use this setup, you must able to link a domain name to the virtual machine's IP address. If you don’t own a domain, services such as `FreeDNS <https://freedns.afraid.org>`_ offer free sub-domains under a range of domains.
 

--- a/odk1-src/aggregate-backup.rst
+++ b/odk1-src/aggregate-backup.rst
@@ -5,6 +5,9 @@
 Backing Up Aggregate
 ====================
 
+.. warning::
+  Aggregate is no longer actively developed. Please use :doc:`ODK Central <central-intro>` instead.
+
 Backup and restore forms and submissions with Briefcase
 -------------------------------------------------------
 

--- a/odk1-src/aggregate-best-practices.rst
+++ b/odk1-src/aggregate-best-practices.rst
@@ -1,6 +1,9 @@
 Tips and Best Practices
 ============================
 
+.. warning::
+  Aggregate is no longer actively developed. Please use :doc:`ODK Central <central-intro>` instead.
+
 .. toctree::
   :maxdepth: 2
 

--- a/odk1-src/aggregate-boost-performance.rst
+++ b/odk1-src/aggregate-boost-performance.rst
@@ -4,6 +4,9 @@ Reducing Data Corruption and Boosting Performance
 =================================================
 
 .. warning::
+  Aggregate is no longer actively developed. Please use :doc:`ODK Central <central-intro>` instead.
+
+.. warning::
 
   This document only applies ODK Aggregate v1.x. See `why we are removing App Engine support <https://forum.getodk.org/t/upcoming-changes-to-aggregate/17582>`_ for more information.
 

--- a/odk1-src/aggregate-data-access.rst
+++ b/odk1-src/aggregate-data-access.rst
@@ -5,6 +5,9 @@
 Getting Data Out of Aggregate
 ================================
 
+.. warning::
+  Aggregate is no longer actively developed. Please use :doc:`ODK Central <central-intro>` instead.
+
 ODK Aggregate supports three primary mechanisms for data transfer:
 
 - :ref:`Exporting <export-data>`:  one time snapshot

--- a/odk1-src/aggregate-data.rst
+++ b/odk1-src/aggregate-data.rst
@@ -1,6 +1,9 @@
 Working with Submitted Data in Aggregate
 =========================================
 
+.. warning::
+  Aggregate is no longer actively developed. Please use :doc:`ODK Central <central-intro>` instead.
+
 You can view the data submitted from ODK Collect here. You can filter the submissions, visualize them using pie chart, bar graph or map, export the submissions into useful formats and publish the submitted data into another service. You can also view all the exported submissions. ODK Aggregate provides all these options under the :guilabel:`Submissions` tab.
 
 .. _filter-submission:

--- a/odk1-src/aggregate-deployment-planning.rst
+++ b/odk1-src/aggregate-deployment-planning.rst
@@ -2,6 +2,9 @@
 Planning Your Aggregate Deployment
 ***********************************
 
+.. warning::
+  Aggregate is no longer actively developed. Please use :doc:`ODK Central <central-intro>` instead.
+
 ODK Aggregate can be deployed to :doc:`any local or cloud server that runs Tomcat, Java8, and PostgreSQL <aggregate-tomcat>` (MySQL is supported too).
 
 You can also use these guides for some specific cloud providers:

--- a/odk1-src/aggregate-digital-ocean.rst
+++ b/odk1-src/aggregate-digital-ocean.rst
@@ -5,6 +5,9 @@ Installing on DigitalOcean (recommended)
 ========================================
 
 .. warning::
+  Aggregate is no longer actively developed. Please use :doc:`ODK Central <central-intro>` instead.
+
+.. warning::
 
   To use this setup, you must able to link a domain name to the machine's IP address. If you don’t own a domain, services such as `FreeDNS <https://freedns.afraid.org>`_ offer free sub-domains under a range of domains.
 

--- a/odk1-src/aggregate-field-length.rst
+++ b/odk1-src/aggregate-field-length.rst
@@ -5,6 +5,9 @@
 Increasing Aggregate Field Length
 ====================================
 
+.. warning::
+  Aggregate is no longer actively developed. Please use :doc:`ODK Central <central-intro>` instead.
+
 By default, Aggregate's datastore layer limits text values to 255 characters or less. If a submission includes a value longer than 255 characters, those additional characters **are not saved in the database** and no warning is shown. That means there is a risk of data loss when using question types that save long text values such as :ref:`geotrace <geotrace-widget>`, :ref:`geoshape <geoshape-widget>` or :ref:`select multiple <multi-select-widget>`. This limitation exists for performance reasons, particularly for older versions of MySQL.
 
 It is possible to set the desired database field length for a particular question. This value can go up to about 16000 UTF-8 characters but the datastore storage efficiency may get worse as the value increases. If you go over 16000 characters, be sure to do an end-to-end test to ensure the performance is acceptable.

--- a/odk1-src/aggregate-forms.rst
+++ b/odk1-src/aggregate-forms.rst
@@ -1,6 +1,9 @@
 Managing Forms in Aggregate
 ================================
 
+.. warning::
+  Aggregate is no longer actively developed. Please use :doc:`ODK Central <central-intro>` instead.
+
 You can add, download and delete forms, export data into useful formats, publish data into another service, manually upload submissions and view the published data. ODK Aggregate provides all these options under the :guilabel:`Form Management` tab.
 
 .. _aggregate-view-blank-form-list:

--- a/odk1-src/aggregate-google-cloud.rst
+++ b/odk1-src/aggregate-google-cloud.rst
@@ -7,6 +7,9 @@ Installing on Google Cloud
 ==========================
 
 .. warning::
+  Aggregate is no longer actively developed. Please use :doc:`ODK Central <central-intro>` instead.
+
+.. warning::
 
   To use this setup, you must able to link a domain name to the machine's IP address. If you don’t own a domain, services such as `FreeDNS <https://freedns.afraid.org>`_ offer free sub-domains under a range of domains.
 

--- a/odk1-src/aggregate-help.rst
+++ b/odk1-src/aggregate-help.rst
@@ -1,6 +1,9 @@
 Getting Help in Aggregate
 =============================
 
+.. warning::
+  Aggregate is no longer actively developed. Please use :doc:`ODK Central <central-intro>` instead.
+
 Aggregate provides three kinds of help accessible by pressing one of three buttons in the upper righthand corner.
 
 The red question mark will give you instructions for the tab you are currently viewing. When you click the button, a help panel will appear at the bottom of the screen. To hide the help panel, simply click the red question mark again.

--- a/odk1-src/aggregate-install.rst
+++ b/odk1-src/aggregate-install.rst
@@ -2,6 +2,9 @@
  Installing Aggregate
 ======================
 
+.. warning::
+  Aggregate is no longer actively developed. Please use :doc:`ODK Central <central-intro>` instead.
+
 .. toctree::
   :maxdepth: 1
 

--- a/odk1-src/aggregate-intro.rst
+++ b/odk1-src/aggregate-intro.rst
@@ -2,7 +2,7 @@ ODK Aggregate
 ===================
 
 .. warning::
-  Aggregate is no longer actively developed. Please consider using :doc:`ODK Central <central-intro>`.
+  Aggregate is no longer actively developed. Please use :doc:`ODK Central <central-intro>` instead.
 
 .. _aggregate-introduction:
 

--- a/odk1-src/aggregate-intro.rst
+++ b/odk1-src/aggregate-intro.rst
@@ -6,9 +6,7 @@ ODK Aggregate
 
 .. _aggregate-introduction:
 
-:dfn:`ODK Aggregate` is the original ODK server. We now encourage using :doc:`ODK Central <central-intro>` which has been developed to address many of the challenges reported by Aggregate users. However, we know that switching may not be immediately practical so we intend to continue providing this documentation.
-
-Aggregate is an open source Java application that
+:dfn:`ODK Aggregate` is an open source Java application that
 stores, analyzes, and presents :doc:`XForm <form-design-intro>` survey data collected using :doc:`collect-intro` or other :doc:`OpenRosa-compliant applications <openrosa>`. It supports a wide range of data types, and is designed to work well in any hosting environment.
 
 With Aggregate, data collection teams can:

--- a/odk1-src/aggregate-intro.rst
+++ b/odk1-src/aggregate-intro.rst
@@ -1,9 +1,14 @@
 ODK Aggregate
 ===================
 
+.. warning::
+  Aggregate is no longer actively developed. Please consider using :doc:`ODK Central <central-intro>`.
+
 .. _aggregate-introduction:
 
-:dfn:`ODK Aggregate` is an open source Java application that
+:dfn:`ODK Aggregate` is the original ODK server. We now encourage using :doc:`ODK Central <central-intro>` which has been developed to address many of the challenges reported by Aggregate users. However, we know that switching may not be immediately practical so we intend to continue providing this documentation.
+
+Aggregate is an open source Java application that
 stores, analyzes, and presents :doc:`XForm <form-design-intro>` survey data collected using :doc:`collect-intro` or other :doc:`OpenRosa-compliant applications <openrosa>`. It supports a wide range of data types, and is designed to work well in any hosting environment.
 
 With Aggregate, data collection teams can:

--- a/odk1-src/aggregate-limitations.rst
+++ b/odk1-src/aggregate-limitations.rst
@@ -1,6 +1,9 @@
 Aggregate Limitations
 ========================
 
+.. warning::
+  Aggregate is no longer actively developed. Please use :doc:`ODK Central <central-intro>` instead.
+
 This is a listing of known limitations and potential "gotchas" users of Aggregate may encounter.
 
 Media held in memory

--- a/odk1-src/aggregate-setup.rst
+++ b/odk1-src/aggregate-setup.rst
@@ -1,6 +1,9 @@
 Setting Up ODK Aggregate
 ===============================
 
+.. warning::
+  Aggregate is no longer actively developed. Please use :doc:`ODK Central <central-intro>` instead.
+
 .. admonition:: Before you get started
   
   If you just want to explore ODK Aggregate, try the `demo server <https://opendatakit.appspot.com>`_.

--- a/odk1-src/aggregate-tomcat.rst
+++ b/odk1-src/aggregate-tomcat.rst
@@ -8,6 +8,9 @@
 Installing on Tomcat
 ====================
 
+.. warning::
+  Aggregate is no longer actively developed. Please use :doc:`ODK Central <central-intro>` instead.
+
 `Apache Tomcat <http://tomcat.apache.org/>`_ is an open source Java web server that can be used to serve ODK Aggregate.
 
 This document guides you through the installation and initial setup of a self-hosted instance of ODK Aggregate, running on Tomcat with a `PostgreSQL <https://www.postgresql.org/>`_, or `MySQL <https://www.mysql.com/>`_ database server. "Self-hosted" could mean on your own hardware or on a cloud-based server.

--- a/odk1-src/aggregate-upgrade.rst
+++ b/odk1-src/aggregate-upgrade.rst
@@ -20,6 +20,9 @@
 Upgrading Aggregate
 =====================
 
+.. warning::
+  Aggregate is no longer actively developed. Please use :doc:`ODK Central <central-intro>` instead.
+
 .. _upgrade-aggregate:
 
 Need for Upgrading

--- a/odk1-src/aggregate-use.rst
+++ b/odk1-src/aggregate-use.rst
@@ -1,6 +1,9 @@
 Using ODK Aggregate
 =====================
 
+.. warning::
+  Aggregate is no longer actively developed. Please use :doc:`ODK Central <central-intro>` instead.
+
 .. toctree::
   :maxdepth: 2
 

--- a/odk1-src/aggregate-visualize.rst
+++ b/odk1-src/aggregate-visualize.rst
@@ -2,6 +2,9 @@
 Visualizing Geographic Data
 ************************************
 
+.. warning::
+  Aggregate is no longer actively developed. Please use :doc:`ODK Central <central-intro>` instead.
+
 This guide helps the users to visualize the collected geodata uploaded on ODK Aggregate server using `Google Earth <https://www.google.com/intl/en_in/earth/>`_.
 
 .. rubric:: Prerequisites

--- a/odk1-src/aggregate-vm.rst
+++ b/odk1-src/aggregate-vm.rst
@@ -6,6 +6,9 @@
 Installing the Virtual Machine
 ==============================
 
+.. warning::
+  Aggregate is no longer actively developed. Please use :doc:`ODK Central <central-intro>` instead.
+
 This document provides instructions for installing :doc:`aggregate-intro` using the Virtual Machine (VM) and `VirtualBox <https://www.virtualbox.org>`_.
 
 .. _setting-up-the-vm:

--- a/odk1-src/briefcase-and-aggregate.rst
+++ b/odk1-src/briefcase-and-aggregate.rst
@@ -1,6 +1,9 @@
 Briefcase and Aggregate
 =========================
 
+.. warning::
+  Aggregate is no longer actively developed. Please use :doc:`ODK Central <central-intro>` instead.
+
 :doc:`ODK Briefcase <briefcase-intro>` and
 :doc:`ODK Aggregate <aggregate-intro>` have
 complementary and overlapping features.

--- a/odk1-src/central-intro.rst
+++ b/odk1-src/central-intro.rst
@@ -3,7 +3,7 @@
 ODK Central
 ===========
 
-:dfn:`ODK Central` is the server component of ODK. It manages user accounts and permissions, stores form definitions, and allows data collection clients like :doc:`ODK Collect <collect-intro>` to connect to it for form download and submission upload.
+:dfn:`ODK Central` is the ODK server. It manages user accounts and permissions, stores form definitions, and allows data collection clients like :doc:`ODK Collect <collect-intro>` to connect to it for form download and submission upload.
 
 Our goal with Central is to create a server that is straightforward to install, easy to use and extensible with new features and functionality both directly in the software and with the use of our REST, OpenRosa, and OData programmatic APIs.
 
@@ -44,19 +44,17 @@ See `What is coming in Central <https://forum.getodk.org/t/whats-coming-in-centr
 Who should use ODK Central?
 ---------------------------
 
-We recommend that all new data collection projects consider using ODK Central because it is in active development by the core ODK team. ODK Central is a relatively new server. It replaces :doc:`aggregate-intro` which is no longer actively maintained. Central isn't as heavily battle-tested as Aggregate, but its developers have put it through stress testing and it is used in production by many projects including several large ones.
+We recommend that all new data collection projects use ODK Central because it is in active development by the core ODK team. ODK Central is a relatively new server. It replaces :doc:`aggregate-intro` which is no longer actively developed. Central isn't as widely deployed as Aggregate, but its developers have put it through stress testing and it is used in production by many projects including several large ones.
 
-Please note that Central does not support every feature that Aggregate does. There are some Aggregate features that we do not intend to ever support in Central, especially around data preview and visualization. You can find a list of these differences and some of the planned improvements to Central `here <https://forum.getodk.org/t/whats-coming-in-central-over-the-next-few-years/19677>`_.
+Central solves some of the biggest problems with Aggregate. Some of our favorite features are:
 
-On the other hand, Central supports some things that Aggregate does not. For example:
-
-- :ref:`direct upload of XLSForm files <central-forms-upload>` makes form management easier
 - :doc:`projects <central-projects>` let you partition your server into different sandboxes to support multiple independent teams
+- :ref:`direct upload of XLSForm files <central-forms-upload>` makes form management easier
 - :ref:`the OData API <central-submissions-odata>` makes it easy to synchronize your live form data to desktop visualization and dashboard tools
 - :doc:`managed encryption <central-encryption>` makes the process of handling encrypted form data significantly easier and in many cases more secure
 
 
-If you are happy with the supported features, please give Central a try and provide your `feedback <https://forum.getodk.org/c/features>`_.
+Please give Central a try and provide your `feedback <https://forum.getodk.org/c/support>`_.
 
 .. _central-performance:
 
@@ -73,7 +71,7 @@ We have done some work to benchmark Central to verify these claims, and produce 
  - A larger 5000 question form, without attachments, could also support 500 devices submitting data at once, but runs more slowly (~12 submissions/second) and fails about one submission in every 1000 (which can then be re-submitted without issues).
  - Including attachments slows the process down, since there is more data to shuffle around. Realistically, the number of concurrent users supported in this scenario will decrease simply because Internet bandwidth in and out of Central will limit the number of submissions it can see at a time. But we have tried situations featuring 5MB submissions with 50 devices at once without seeing issues (though for the mentioned reasons the response rate drops to between 1 and 2 submissions/second). Additionally, data exports with attachments take longer and are more memory-intensive.
 
- When you are planning for your installation and selecting a destination to deploy Central to, keep these numbers in mind. If 500 people submitting data *all at the same time* is a laughably distant scenario, you can probably get by with a lower-performance option. If your deployment is larger than these numbers, consider bumping up to a more powerful machine. If you aren't sure, ask around in the forums.
+ When you are planning for your installation and selecting a destination to deploy Central to, keep these numbers in mind. If 500 people submitting data *all at the same time* is a distant scenario, you can probably get by with a lower-performance option. If your deployment is larger than these numbers, consider bumping up to a more powerful machine. If you aren't sure, ask around in the forums.
 
 .. _central-intro-learn-more:
 

--- a/odk1-src/central-intro.rst
+++ b/odk1-src/central-intro.rst
@@ -3,9 +3,9 @@
 ODK Central
 ===========
 
-:dfn:`ODK Central` is an ODK server alternative that is early in its development. Like ODK Aggregate, it manages user accounts and permissions, stores form definitions, and allows data collection clients like ODK Collect to connect to it for form download and submission upload.
+:dfn:`ODK Central` is the server component of ODK. It manages user accounts and permissions, stores form definitions, and allows data collection clients like :doc:`ODK Collect <collect-intro>` to connect to it for form download and submission upload.
 
-Our goal with Central is to create a modern sibling to Aggregate that is easier to install, easier to use, and more extensible with new features and functionality both directly in the software and with the use of our REST, OpenRosa, and OData programmatic APIs.
+Our goal with Central is to create a server that is straightforward to install, easy to use and extensible with new features and functionality both directly in the software and with the use of our REST, OpenRosa, and OData programmatic APIs.
 
 .. _central-intro-features:
 
@@ -44,15 +44,19 @@ See `What is coming in Central <https://forum.getodk.org/t/whats-coming-in-centr
 Who should use ODK Central?
 ---------------------------
 
-Central is much younger than Aggregate. Because of this, it isn't as heavily battle-tested, and you might come across quirks and problems while using it. Among other things, it can be a little tricky to install. But the issues people have run into have been minor so far.
+We recommend that all new data collection projects consider using ODK Central because it is in active development by the core ODK team. ODK Central is a relatively new server. It replaces :doc:`aggregate-intro` which is no longer actively maintained. Central isn't as heavily battle-tested as Aggregate, but its developers have put it through stress testing and it is used in production by many projects including several large ones.
 
-Additionally, Central does not support every feature that Aggregate does. There are some Aggregate features that we do not intend to ever support in Central, especially around data preview and visualization. You can find a list of these differences and some of the planned improvements to Central `here <https://forum.getodk.org/t/whats-coming-in-central-over-the-next-few-years/19677>`_.
+Please note that Central does not support every feature that Aggregate does. There are some Aggregate features that we do not intend to ever support in Central, especially around data preview and visualization. You can find a list of these differences and some of the planned improvements to Central `here <https://forum.getodk.org/t/whats-coming-in-central-over-the-next-few-years/19677>`_.
 
-On the other hand, Central supports some things that Aggregate does not. Projects let you partition your server into different sandboxes to support multiple independent teams. Managed encryption makes the process of handling encrypted form data significantly easier and in many cases more securely. Central allows direct upload of XLSForm files. It also offers an OData API to easily synchronize your live form data to desktop visualization and dashboard tools.
+On the other hand, Central supports some things that Aggregate does not. For example:
 
-If you are an adventurous user who is comfortable with (new) technology, you are happy with the supported features, and you are okay with the risks with using early release software, please consider giving Central a try and giving us your `feedback <https://forum.getodk.org/c/features>`_.
+- :ref:`direct upload of XLSForm files <central-forms-upload>` makes form management easier
+- :doc:`projects <central-projects>` let you partition your server into different sandboxes to support multiple independent teams
+- :ref:`the OData API <central-submissions-odata>` makes it easy to synchronize your live form data to desktop visualization and dashboard tools
+- :doc:`managed encryption <central-encryption>` makes the process of handling encrypted form data significantly easier and in many cases more secure
 
-If you finished reading all the above and you're not feeling too sure about it, we suggest sitting it out for a little while longer. Keep watching the `release announcements board <https://forum.getodk.org/c/releases>`_ for future updates, and we'll be sure to sound the bells when we're sure things are ready for a broader audience.
+
+If you are happy with the supported features, please give Central a try and provide your `feedback <https://forum.getodk.org/c/features>`_.
 
 .. _central-performance:
 
@@ -67,9 +71,9 @@ We have done some work to benchmark Central to verify these claims, and produce 
 
  - A 250 question form without attachments could support 500 devices simultaneously uploading many submissions without issues, at a rate of roughly 41.2 submissions per second.
  - A larger 5000 question form, without attachments, could also support 500 devices submitting data at once, but runs more slowly (~12 submissions/second) and fails about one submission in every 1000 (which can then be re-submitted without issues).
- - Including attachments slows the process down, since there is more data to shuffle around. Realistically, the number of concurrent users supported in this scenario will decrease simply because Internet bandwidth in and out of Central will limit the number of submissions it can see at a time. But we have tried situations featuring 5MB submissions with 50 devices at once without seeing issues (though for the mentioned reasons the response rate drops to between 1 and 2 submissions/second).
+ - Including attachments slows the process down, since there is more data to shuffle around. Realistically, the number of concurrent users supported in this scenario will decrease simply because Internet bandwidth in and out of Central will limit the number of submissions it can see at a time. But we have tried situations featuring 5MB submissions with 50 devices at once without seeing issues (though for the mentioned reasons the response rate drops to between 1 and 2 submissions/second). Additionally, data exports with attachments take longer and are more memory-intensive.
 
- When you are planning for your installation and selecting a destination to deploy Central to, keep these numbers in mind. If 500 people submitting data *all at the same time* is a laughably distant scenario, you can probably get by with an even cheaper option. If your deployment is larger than these numbers, consider bumping up to a more powerful machine. If you aren't sure, ask around in the forums.
+ When you are planning for your installation and selecting a destination to deploy Central to, keep these numbers in mind. If 500 people submitting data *all at the same time* is a laughably distant scenario, you can probably get by with a lower-performance option. If your deployment is larger than these numbers, consider bumping up to a more powerful machine. If you aren't sure, ask around in the forums.
 
 .. _central-intro-learn-more:
 

--- a/odk1-src/collect-connect.rst
+++ b/odk1-src/collect-connect.rst
@@ -1,13 +1,13 @@
 Connecting to a Server
 ========================
 
-ODK Collect is used to fill forms with participants. Filled forms then need to be aggregated in a central location for review and analysis. Generally, organizations do this by configuring Collect to send forms to a server. For those working in environments without any internet connectivity, there are :ref:`other options <other-collect-server-options>`.
+ODK Collect is used to fill forms with participants. Filled forms then need to be sent to a central location for review and analysis. Generally, organizations do this by configuring Collect to send forms to a server. For those working in environments without any internet connectivity, there are :ref:`other options <other-collect-server-options>`.
 
 When you first install Collect, it connects to `a demo server <https://opendatakit.appspot.com/Aggregate.html>`_. This allows you to try out the app by :ref:`downloading blank example forms <in-app-get-blank-forms>`, :doc:`filling them out <collect-filling-forms>`, and :ref:`uploading completed forms <uploading-forms>` back to the demo server.
   
-Once you are done trying out Collect, you will need to decide on a plan for managing forms and data submissions. We typically recommend using `ODK Central <central-intro>` and configuring Collect by QR code. :doc:`ODK Central <central-intro>` provides user and project management features as well as tools for viewing and exporting data. For complex data collection projects, it is usually the right choice. Organizations with strict privacy requirements can choose to use their own infrastructure and have total control over their server configuration. However, setting up and maintaining a server can be challenging.
+Once you are done trying out Collect, you will need a plan for managing forms and data submissions. We recommend using `ODK Central <central-intro>` and configuring Collect by QR code. :doc:`ODK Central <central-intro>` provides user and project management features as well as tools for viewing and exporting data. For complex data collection projects, it is usually the right choice. Organizations can choose to use their own infrastructure and have total control over their server configuration. However, setting up and maintaining a server requires technical skills.
 
-Simple projects without strict privacy requirements can choose to send data directly to Google Sheets.
+Simple projects can choose to send data directly to Google Sheets.
 
 .. _collect-connect-qr-code:
 

--- a/odk1-src/collect-connect.rst
+++ b/odk1-src/collect-connect.rst
@@ -1,29 +1,19 @@
-.. spelling::
-
-  SMS
-
 Connecting to a Server
-================================
+========================
 
 ODK Collect is used to complete surveys with participants. Filled surveys then need to be aggregated in a central location for review and analysis. Generally, organizations do this by configuring Collect to send forms to a server. For those working in environments without any internet connectivity, there are :ref:`other options <other-collect-server-options>`.
 
-.. note::
-
-  When you first install Collect, it connects to the `ODK Aggregate Demo server <https://opendatakit.appspot.com/Aggregate.html>`_. This allows you to try out the app by :ref:`downloading blank example forms <in-app-get-blank-forms>`, :doc:`filling them out   <collect-filling-forms>`, and :ref:`uploading completed forms <uploading-forms>` back to the demo server.
+When you first install Collect, it connects to `a demo server <https://opendatakit.appspot.com/Aggregate.html>`_. This allows you to try out the app by :ref:`downloading blank example forms <in-app-get-blank-forms>`, :doc:`filling them out <collect-filling-forms>`, and :ref:`uploading completed forms <uploading-forms>` back to the demo server.
   
-  Once you are done "trying out" Collect, and you start actually using it, you will need to decide on a plan for managing forms and data submissions.
+Once you are done trying out Collect, you will need to decide on a plan for managing forms and data submissions. We typically recommend using `ODK Central <central-intro>` and configuring Collect by QR code. :doc:`ODK Central <central-intro>` provides user and project management features as well as tools for viewing and exporting data. For complex data collection projects, it is usually the right choice. Organizations with strict privacy requirements can choose to use their own infrastructure and have total control over their server configuration. However, setting up and maintaining a server can be challenging.
 
-The two most common options for form and data management are:
+Simple projects can choose to send data directly to Google Sheets. Please make sure that this meets your privacy requirements.
 
 .. toctree::
   :maxdepth: 2
 
   collect-connect-aggregate
   collect-connect-google
- 
-:doc:`aggregate-intro` provides a robust data repository with tools for data visualization, querying, and export. For complex data collection and aggregation tasks, it is usually the right choice. However, setting up and maintaining an Aggregate server is not a trivial matter. 
-
-Using Google Drive to manage form submissions is simpler and, in most cases, cheaper. With this simplicity you sacrifice a richer feature set. Additionally, using Google Drive may not meet your privacy requirements.
 
 .. _other-collect-server-options:
 

--- a/odk1-src/collect-connect.rst
+++ b/odk1-src/collect-connect.rst
@@ -1,30 +1,45 @@
 Connecting to a Server
 ========================
 
-ODK Collect is used to complete surveys with participants. Filled surveys then need to be aggregated in a central location for review and analysis. Generally, organizations do this by configuring Collect to send forms to a server. For those working in environments without any internet connectivity, there are :ref:`other options <other-collect-server-options>`.
+ODK Collect is used to fill forms with participants. Filled forms then need to be aggregated in a central location for review and analysis. Generally, organizations do this by configuring Collect to send forms to a server. For those working in environments without any internet connectivity, there are :ref:`other options <other-collect-server-options>`.
 
 When you first install Collect, it connects to `a demo server <https://opendatakit.appspot.com/Aggregate.html>`_. This allows you to try out the app by :ref:`downloading blank example forms <in-app-get-blank-forms>`, :doc:`filling them out <collect-filling-forms>`, and :ref:`uploading completed forms <uploading-forms>` back to the demo server.
   
 Once you are done trying out Collect, you will need to decide on a plan for managing forms and data submissions. We typically recommend using `ODK Central <central-intro>` and configuring Collect by QR code. :doc:`ODK Central <central-intro>` provides user and project management features as well as tools for viewing and exporting data. For complex data collection projects, it is usually the right choice. Organizations with strict privacy requirements can choose to use their own infrastructure and have total control over their server configuration. However, setting up and maintaining a server can be challenging.
 
-Simple projects can choose to send data directly to Google Sheets. Please make sure that this meets your privacy requirements.
+Simple projects without strict privacy requirements can choose to send data directly to Google Sheets.
 
-.. toctree::
-  :maxdepth: 2
+.. _collect-connect-qr-code:
 
-  collect-connect-aggregate
-  collect-connect-google
+Configure server from QR code
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+1. From the Action Button (:guilabel:`⋮`), select :menuselection:`Configure via QR code`
+
+.. image:: /img/collect-configure/quick-qr-code.*
+  :alt: Configure via QR code
+  :class: device-screen-vertical
+
+1. Position the QR code in the center of the camera field, under the red line. When the camera focuses on the code, it will beep and scan the code.
+
+1. Collect will apply the settings from the code and go back to the landing screen.
+
+.. seealso::
+
+  - :doc:`central-setup`
+  - :ref:`Central App Users <central-users-app-overview>`
+  - :doc:`collect-import-export`
+
 
 .. _other-collect-server-options:
 
 Other options
 ~~~~~~~~~~~~~~~
 
+.. toctree::
+  :maxdepth: 1
 
-Managing forms from an ODK Aggregate server or Google Drive is typical. However, there are other ways to use Collect.
-
- - :ref:`Transfer blank forms directly to your device <loading-forms-directly>`
- - :doc:`Pull completed forms directly with adb <collect-adb>`
- - :doc:`Use ODK Briefcase  <briefcase-using>`
-
-.. - :doc:`Send submissions via SMS (text message) <collect-sms-submissions>`
+  collect-connect-google
+  collect-connect-aggregate
+  Transfering blank and completed forms directly with adb <collect-adb>
+  Using ODK Briefcase  <briefcase-using>

--- a/odk1-src/collect-forms.rst
+++ b/odk1-src/collect-forms.rst
@@ -17,21 +17,19 @@ In order to fill out forms with survey participants, you must first load blank f
 
 .. _in-app-get-blank-forms:
 
-Loading Forms from ODK Aggregate Server or Google Drive
-------------------------------------------------------------
+Loading Forms from a server
+-----------------------------
 
-If you have :doc:`connected ODK Collect to a server  <collect-connect>` or :doc:`Google Drive  <collect-connect-google>`:
+If you have connected ODK Collect to a :doc:`server <collect-connect>` or :doc:`Google Drive Account <collect-connect-google>`:
 
 1. Select :guilabel:`Get blank forms` on the app home screen to browse available forms and download them to your device.
 
    .. image:: /img/collect-forms/main-menu-highlight-get-blank-form.*
      :alt: The Main Menu of the Collect app. The option *Get Blank Form* is circled in red.
 
-
-
 2. Find and download forms.
 
-   - If you are using ODK Aggregate, you will see a list of available forms. Select the ones you would like download, and tap :guilabel:`Get Selected`.
+   - If you are using a server, you will see a list of available forms. Select the ones you would like download, and tap :guilabel:`Get Selected`.
 
 
      .. image:: /img/collect-forms/get-blank-form.*
@@ -40,7 +38,7 @@ If you have :doc:`connected ODK Collect to a server  <collect-connect>` or :doc:
 
     .. note::
 
-      Before downloading blank forms from Aggregate to Collect, a form has to be uploaded. See :doc:`Form Management in ODK Aggregate  <aggregate-forms>`.
+      Before downloading blank forms from your server to Collect, a form has to be uploaded. See :doc:`Form Management in ODK Central  <central-forms>`.
 
    - If you are using Google Drive, the **Get Blank Form** screen will display the folders in your Google Drive account and any XML documents. Select and download the forms you want.
 
@@ -111,9 +109,9 @@ Loading form media
 
 If a form :ref:`includes images or other media <media>`, those files have to be loaded to the device along with the form.
 
-Media files should be placed in a folder labeled :file:`{form-name}-media`.
+Media files must be placed in a folder labeled :file:`{form-name}-media`.
 
-- When using ODK Aggregate, the form upload prompt includes instructions to upload the :file:`-media` folder. The files are downloaded automatically when :ref:`fetching forms from Aggregate <in-app-get-blank-forms>`.
+- When using ODK Central, first upload your form definition. Central will then prompt you to :ref:`add media files <central-forms-attachments>` if necessary. The files are downloaded automatically when :ref:`fetching blank forms <in-app-get-blank-forms>`.
 - When using Google Drive, the :file:`-media` folder should be uploaded to the same location as the form. If you share forms with another user, you need to share the parent folder which contains a form and a folder with media files. Sharing both of them separately wouldn't be enough.
 - If :ref:`loading forms directly to your device <loading-forms-directly>`, the :file:`-media` folder needs to be placed in the :file:`forms` subdirectory of :ref:`your Collect directory <collect-directory>`, alongside the form itself.
 
@@ -159,7 +157,7 @@ In some cases, you may want to :ref:`pull filled forms directly from a device <p
 Sending Finalized Forms to a Server
 -----------------------------------
 
-If you are connected to :doc:`a server <collect-connect-aggregate>` or :doc:`Google Drive Account <collect-connect-google>`, use :guilabel:`Send Finalized Forms` to upload :formstate:`Finalized` form instances.
+If you are connected to :doc:`a server <collect-connect>` or :doc:`Google Drive Account <collect-connect-google>`, use :guilabel:`Send Finalized Forms` to upload :formstate:`Finalized` form instances.
 
 Uploading a filled form from within the Collect app marks that form as :formstate:`sent`. :formstate:`Sent` forms are no longer editable, but they remain viewable until they are deleted.
 

--- a/odk1-src/collect-settings.rst
+++ b/odk1-src/collect-settings.rst
@@ -61,7 +61,7 @@ To access General Settings:
 Server Settings
 ~~~~~~~~~~~~~~~~~
 
-Server settings :doc:`configure the connection to an <collect-connect>` :doc:`openrosa` server (:doc:`Aggregate <aggregate-intro>`, :doc:`Central <central-intro>`, etc) or a :doc:`Google Drive account <collect-connect-google>`.
+Server settings :doc:`configure the connection to an <collect-connect>` :doc:`openrosa` server (:doc:`Central <central-intro>`, etc) or a :doc:`Google Drive account <collect-connect-google>`.
 
 To access Server Settings:
   :menuselection:`⋮ --> General Settings --> Server`

--- a/odk1-src/encrypted-forms.rst
+++ b/odk1-src/encrypted-forms.rst
@@ -8,7 +8,7 @@ Overview
 ====================
 Encrypted forms provide a mechanism to keep your data private even when using **http:** for communications (for example, when you do not have an **SSL certificate** or **https:** is not available). Encrypted forms may also enable Google App Engine deployments (and deployments using other web database services, such as, AWS) to comply with data privacy laws, eliminating the necessity for setting up your own servers to meet those requirements.
 
-Encrypted forms apply asymmetric public key encryption at the time the form is finalized within ODK Collect. This encrypted form can then be submitted to a server. ODK Central provides `a managed encryption option <central-encryption>` which means a decrypted data file can securely be downloaded without using any other tool. ODK Central self-managed encryption and other servers require using ODK Briefcase to download and decrypt the data. ODK Briefcase, when supplied with the asymmetric private key (which ODK Briefcase never stores), can then decrypt and export the form data as a CSV file for your use.
+Encrypted forms apply asymmetric public key encryption at the time the form is finalized within ODK Collect. This encrypted form can then be submitted to a server. ODK Central provides `a managed encryption option <central-encryption>` which means a decrypted data file can securely be downloaded without using any other tool. Central self-managed encryption and other servers require using ODK Briefcase to download and decrypt the data. Briefcase, when supplied with the asymmetric private key (which Briefcase never stores), can then decrypt and export the form data as a CSV file for your use.
 
 The finalized form's data (and media attachments) are encrypted before being submitted to a server and remain encrypted while stored on the server. When using Briefcase, the data remains encrypted as it is pulled, where it is again stored in encrypted form.
 
@@ -17,7 +17,7 @@ The finalized form's data (and media attachments) are encrypted before being sub
   - A server cannot present or share the data with another service since the encryption obscures the entire contents of the form and the server never possesses the asymmetric key required to decrypt the form.
   - When using encrypted forms, the server serves only as a data aggregation point.
 
-The non-encrypted data is available on the ODK Collect device during data collection and whenever a form is saved without marking it as complete. Once you mark a form as complete (finalize it), ODK Collect will generate a random 256-bit symmetric key, encrypt the form contents and all attachments with this key, then construct a submission manifest which describes the encrypted submission and an asymmetric-key encryption of the symmetric key used for the encryption. This manifest is the "form" that is uploaded to a server, with the encrypted form contents and its encrypted attachments appearing as attachments to this submission manifest "form."
+The non-encrypted data is available on the ODK Collect device during data collection and whenever a form is saved without marking it as complete. Once you mark a form as complete (finalize it), Collect will generate a random 256-bit symmetric key, encrypt the form contents and all attachments with this key, then construct a submission manifest which describes the encrypted submission and an asymmetric-key encryption of the symmetric key used for the encryption. This manifest is the "form" that is uploaded to a server, with the encrypted form contents and its encrypted attachments appearing as attachments to this submission manifest "form."
 
 .. _encrypt-requirements:
 
@@ -121,7 +121,7 @@ Uploading Finalized Forms
 
 If you are using :doc:`XLSForm <xlsform>`, then form encryption is governed by the :guilabel:`settings` on the `Settings Worksheet <http://xlsform.org/#settings_ws>`_. Encrypted forms must specify a *submission_url* and a *public_key* on this worksheet. If both are specified, XLSForm will generate an encrypted-form definition. Skip to the following sections to see how to create a public-private key pair and specify the public key.
 
-The required element to make this form an encrypted form is the ``<submission/>`` tag. Within this tag, the method attribute should always be **form-data-post**. The action attribute should be the url to which the submission should be posted. For Central, this is the server URL configured in Collect for the App User followed by `/submission`. For Aggregate, this is the ODK Aggregate website url with Aggregate.html replaced by `submission`. Finally, what identifies the form as an encrypted form is the presence of a *base64RsaPublicKey* attribute. This should be the base64 encoding of the RSA public key that ODK Collect uses to encrypt the symmetric encryption key it creates to encrypt a finalized instance of this form (a different symmetric encryption key is created for every finalized form)
+The required element to make this form an encrypted form is the ``<submission/>`` tag. Within this tag, the method attribute should always be **form-data-post**. The action attribute should be the url to which the submission should be posted. For Central, this is the server URL configured in Collect for the App User followed by `/submission`. For Aggregate, this is the url with Aggregate.html replaced by `submission`. Finally, what identifies the form as an encrypted form is the presence of a *base64RsaPublicKey* attribute. This should be the base64 encoding of the RSA public key that Collect uses to encrypt the symmetric encryption key it creates to encrypt a finalized instance of this form (a different symmetric encryption key is created for every finalized form)
 
 .. _create-RSA-key:
 
@@ -231,7 +231,7 @@ Open the :file:`MyPublicKey.pem` file and copy the resulting very-long string in
 Operations
 ===========================
 
-Operationally, you would add the form definition to the server identified in the ``<submission>`` tag's action attribute, and deploy everything using ODK Collect, figure out how you want to implement a periodic SD Card wiping protocol for your devices, and you're done. Submissions will be encrypted when marked as complete. Once the data is on your server, use ODK Briefcase to download the encrypted submissions to your desktop computer, and then specify the private key PEM file when decrypting and generating the CSV files.
+Operationally, you would add the form definition to the server identified in the ``<submission>`` tag's action attribute, and deploy everything using Collect, figure out how you want to implement a periodic SD Card wiping protocol for your devices, and you're done. Submissions will be encrypted when marked as complete. Once the data is on your server, use Briefcase to download the encrypted submissions to your desktop computer, and then specify the private key PEM file when decrypting and generating the CSV files.
 
 .. note::
   - ODK Central or ODK Aggregate will only hold the encrypted submission with no access to the private key

--- a/odk1-src/form-audit-log.rst
+++ b/odk1-src/form-audit-log.rst
@@ -17,7 +17,7 @@ Collect can log the behavior of enumerators as they navigate through a form. Thi
 
 This information can inform form design and training.
 
-.. admonition:: Aggregate 1.5.0+ required
+.. admonition:: If using Aggregate, Aggregate 1.5.0+ required
 
   If a version of Aggregate lower than 1.5.0 is used, **audit files will not be saved on the server**.
 
@@ -130,7 +130,9 @@ This will cause Collect to prompt the enumerator for their identity before filli
 Viewing audit logs
 -------------------
 
-Audit logs can be reviewed in Aggregate and downloaded for further analysis using Briefcase.
+Central will export a CSV with audits from all submissions if an export is requested for a form with an audit.
+
+If using Aggregate, audit logs can be reviewed and downloaded for further analysis using Briefcase.
 
 In Aggregate 1.5.0+, audit logs can be viewed by clicking on the media icon in the :th:`meta audit` column on the Submissions page:
 

--- a/odk1-src/form-logic.rst
+++ b/odk1-src/form-logic.rst
@@ -587,7 +587,7 @@ You can ask the same question or questions multiple times by wrapping them in :t
     :doc:`form-repeats` describes strategies to address common repetition scenarios.
 
 .. tip::
-  Using repetition in a form is very powerful but can also make training and data analysis more time-consuming. Repeats exported from Central or Briefcase be in their own documents and will need to be joined with their parent records for analysis.
+  Using repetition in a form is very powerful but can also make training and data analysis more time-consuming. Repeats exported from Central or Briefcase be in their own files and will need to be joined with their parent records for analysis.
 
   Before adding repeats to your form, consider other options:
 

--- a/odk1-src/form-logic.rst
+++ b/odk1-src/form-logic.rst
@@ -587,7 +587,7 @@ You can ask the same question or questions multiple times by wrapping them in :t
     :doc:`form-repeats` describes strategies to address common repetition scenarios.
 
 .. tip::
-  Using repetition in a form is very powerful but can also make training and data analysis more time-consuming. Aggregate does not export repeats so Briefcase or one of the data publishers will be needed to :doc:`transfer data from Aggregate <aggregate-data-access>`. Repeats will be in their own documents and will need to be joined with their parent records for analysis.
+  Using repetition in a form is very powerful but can also make training and data analysis more time-consuming. Repeats exported from Central or Briefcase be in their own documents and will need to be joined with their parent records for analysis.
 
   Before adding repeats to your form, consider other options:
 

--- a/odk1-src/form-update.rst
+++ b/odk1-src/form-update.rst
@@ -28,8 +28,12 @@
   las
   th
 
-Updating forms
-=================
+Updating forms in Aggregate
+============================
+
+.. note::
+
+  This page is only about ODK Aggregate. ODK Central allows any kind of form update that doesn't change the type of a field. See :ref:`central-forms-updates`.
 
 .. _change-existing:
 

--- a/odk1-src/getting-started.rst
+++ b/odk1-src/getting-started.rst
@@ -17,7 +17,7 @@ The easiest way to install the Collect app is `to get it from the Google Play st
 
 .. seealso:: :doc:`collect-install`
 
-.. _getting-started-install-aggregate:
+.. _getting-started-install-central:
 
 Install Central
 ----------------

--- a/odk1-src/getting-started.rst
+++ b/odk1-src/getting-started.rst
@@ -1,8 +1,7 @@
 Getting Started With ODK
 =========================
 
-This document walks you through a very basic setup process,
-to get you familiar with using ODK.
+This document walks you through the recommended workflow to get started with ODK.
 
 You will:
 
@@ -20,76 +19,45 @@ The easiest way to install the Collect app is `to get it from the Google Play st
 
 .. _getting-started-install-aggregate:
 
-Install Aggregate (optional)
-------------------------------
+Install Central
+----------------
 
-The easiest way to set up Aggregate is to
-:doc:`install it on Google App engine <aggregate-app-engine>`. 
+The easiest way to set up your own Central server is to :doc:`install it on DigitalOcean <central-install-digital-ocean>`, a cloud provider.
 
-You'll set up a new Google Cloud project, and then run the installer locally. This will connect to your Google Cloud account and install Aggregate there.
-
-Alternatively, if you only want to try things out,
-you can use the `Aggregate sandbox server`_.
-
-
+If you want to try Central out, you can :ref:`request access to the sandbox <central-install-sandbox>`.
 
 .. warning::
 
-  The `Aggregate sandbox server`_ is for demo purposes only.
-  All forms and data on this server are public and are deleted every 24 hours without notice.
+  The Central sandbox server is for evaluation purposes only. All forms and data on this server are public and may be deleted without notice.
   
-.. _Aggregate sandbox server: https://sandbox.aggregate.getodk.org
-
-.. seealso:: :doc:`aggregate-install`
+.. seealso:: :doc:`central-install`
 
 .. _getting-started-create-form:
 
-Create a form with Build and upload it to Aggregate
+Create a form with XLSForm and upload it to Central
 ------------------------------------------------------
-
-The quickest and easiest way to start using your own survey forms is to create one online with `ODK Build <https://build.getodk.org/>`_.
-
-#. Go to `build.getodk.org <https://build.getodk.org/>`_, create a new account, and log in. Once logged in, a blank survey is created. 
-#. Give your form a name (:guilabel:`rename` in the upper left-hand corner).
-#. Add a few questions (click on question types in the :guilabel:`+Add New` bar along the bottom).
-#. Once your new form is complete, go to :menuselection:`File --> Upload form to Aggregate...` to upload your form.
-
-   If you have your own Aggregate server, use the URI and credentials you created during setup.
-   
-   To use the sandbox, the :guilabel:`Aggregate Instance URI` is ``https://sandbox.aggregate.getodk.org``. You should not need additional credentials.
-
-
-.. seealso::
-  
-  `Build desktop app <https://github.com/getodk/build/releases/latest>`_
-    To use Build locally.
-
-  :doc:`xlsform`
-    A more robust form creation tool.
-  
+#. Create a document in your favorite spreadsheet tool (Excel, Google Sheets, etc)
+#. Design your form using :doc:`XLSForm <xlsform>` or try `a sample XLSForm <https://docs.google.com/spreadsheets/d/1af_Sl8A_L8_EULbhRLHVl8OclCfco09Hq2tqb9CslwQ/edit#gid=0>`_.
+#. :ref:`Upload the form to Central <central-forms-upload>`.
     
 .. _getting-started-load-form:
 
-Load a form into Collect from Aggregate
+Load a form into Collect from Central
 ----------------------------------------------------------
 
-#. Open Collect on your Android device.
-#. Open server settings 
-   (:menuselection:`⋮ --> General Settings --> Server`).
-#. Edit the server settings to connect to your Aggregate server or the sandbox server.
-
-   The URI for the sandbox server is ``https://sandbox.aggregate.getodk.org``.
-   
+#. :ref:`Find or create an App User <central-users-app-overview>` in Central
+#. Open Collect on your Android device
+#. Tap :guilabel:`Configure via QR code` from the menu at the top right
+   (:menuselection:`⋮ --> Configure via QR code`)
+#. Scan the QR code from Central
 #. Go back to the app home screen and select :guilabel:`Get Blank Form`, then select your form.
-
 
 .. _getting-started-fill-form:
 
-Fill out a form and upload it to Aggregate
+Fill out a form and upload it to Central
 -------------------------------------------
 
 #. Select :guilabel:`Fill Blank Form` to complete a survey.
-#. Select :guilabel:`Send Finalized Form` to upload your completed survey to Aggregate.
+#. Select :guilabel:`Send Finalized Form` to upload your completed survey to Central.
 
-
-Now log back into Aggregate and see your completed survey results.
+Now log back into Central and see your completed survey results.

--- a/odk1-src/index.rst
+++ b/odk1-src/index.rst
@@ -59,27 +59,6 @@ For a complete list of our tools, check out `ODK on GitHub <https://github.com/g
 .. toctree::
   :hidden:
   :maxdepth: 2
-  :caption: Aggregate
-
-  aggregate-intro
-  aggregate-setup
-  aggregate-use
-  aggregate-best-practices
-  aggregate-app-engine-legacy
-
-.. toctree::
-  :hidden:
-  :maxdepth: 2
-  :caption: Briefcase
-
-  briefcase-intro
-  briefcase-install
-  briefcase-using
-  briefcase-and-aggregate
-
-.. toctree::
-  :hidden:
-  :maxdepth: 2
   :caption: Central
 
   central-intro
@@ -102,6 +81,27 @@ For a complete list of our tools, check out `ODK on GitHub <https://github.com/g
   launch-apps-from-collect
   form-tools
   form-best-practices
+
+.. toctree::
+  :hidden:
+  :maxdepth: 2
+  :caption: Briefcase
+
+  briefcase-intro
+  briefcase-install
+  briefcase-using
+  briefcase-and-aggregate
+
+.. toctree::
+  :hidden:
+  :maxdepth: 2
+  :caption: Aggregate
+
+  aggregate-intro
+  aggregate-setup
+  aggregate-use
+  aggregate-best-practices
+  aggregate-app-engine-legacy
 
 .. toctree::
   :hidden:

--- a/odk1-src/index.rst
+++ b/odk1-src/index.rst
@@ -11,7 +11,7 @@ Welcome to ODK's Docs!
 For a quick start, read :doc:`getting-started`. In most cases, users of ODK:
 
 - Create survey forms using the `XLSForm <http://xlsform.org/>`_ standard in Excel or `Google Sheets <https://www.google.com/sheets/>`_.
-- :ref:`Upload forms <central-forms>` to an :doc:`ODK Central server <central-intro>`.
+- :ref:`Upload forms <central-forms-upload>` to an :doc:`ODK Central server <central-intro>`.
 - :ref:`Download forms <in-app-get-blank-forms>` into :doc:`collect-intro` on an Android device.
 - :doc:`Use Collect to fill out forms <collect-filling-forms>` with :term:`participants <participant>`.
 - :ref:`Upload survey data <uploading-forms>` from Collect to Central.

--- a/odk1-src/index.rst
+++ b/odk1-src/index.rst
@@ -8,13 +8,26 @@ Welcome to ODK's Docs!
 
 :dfn:`ODK` is a suite of open source tools that help organizations collect and manage data.
 
-The core ODK tools are:
+For a quick start, read :doc:`getting-started`. In most cases, users of ODK:
 
-- :doc:`collect-intro`, an Android app that replaces paper-based forms.
-- :doc:`aggregate-intro`, a proven server for data storage and analysis tool.
-- :doc:`central-intro`, a modern server with a RESTful API.
-- :doc:`build-intro`, a drag-and-drop form designer.
-- :doc:`ODK XLSForm </xlsform>`, an Excel-based form designer.
+- Create survey forms using the `XLSForm <http://xlsform.org/>`_ standard in Excel or `Google Sheets <https://www.google.com/sheets/>`_.
+- :ref:`Upload forms <central-forms>` to an :doc:`ODK Central server <central-intro>`.
+- :ref:`Download forms <in-app-get-blank-forms>` into :doc:`collect-intro` on an Android device.
+- :doc:`Use Collect to fill out forms <collect-filling-forms>` with :term:`participants <participant>`.
+- :ref:`Upload survey data <uploading-forms>` from Collect to Central.
+- :doc:`Analyze or export data from Central <central-submissions>`.
+
+This requires:
+
+- :doc:`Installing Collect on an Android device <collect-install>`
+- :doc:`Installing Central on a server <central-setup>`
+
+While this is the recommended workflow, it is not the only way to do things. ODK is a very flexible set of tools, and organizations will find their own best practices for adopting it.
+
+Additional ODK tools are:
+
+- :doc:`aggregate-intro`, a proven server. We now generally recommend Central but those with existing Aggregate servers may choose to continue using them.
+- :doc:`build-intro`, a drag-and-drop form designer. We generally recommend XLSForm for its flexibility but users only building very simple forms may prefer Build.
 - :doc:`briefcase-intro`, a desktop tool that pulls and exports data from Aggregate and Collect.
 
 The specifications and libraries that power the tools are:
@@ -26,28 +39,6 @@ The specifications and libraries that power the tools are:
 - `pyxform <https://github.com/xlsform/pyxform>`_, a Python library that converts XLSForms into ODK XForms.
 
 For a complete list of our tools, check out `ODK on GitHub <https://github.com/getodk>`_.
-
-.. _using-odk:
-
-How is ODK used?
-------------------
-
-For a quick start, read :doc:`getting-started`. In most cases, users of ODK:
-
-- Create survey forms using `Build <https://build.getodk.org/>`_ or `XLSForm <http://xlsform.org/>`_.
-- :ref:`Upload forms <aggregate-add-new-forms>` to an :doc:`aggregate-intro` server.
-- :ref:`Load forms <in-app-get-blank-forms>` into :doc:`collect-intro` on an Android device.
-- :doc:`Use Collect to fill out forms <collect-filling-forms>` with :term:`participants <participant>`.
-- :ref:`Upload survey data <uploading-forms>` from Collect to Aggregate.
-- :doc:`Analyze or export data in Aggregate <aggregate-data>`.
-
-This requires:
-
-- :doc:`Installing Collect on a phone or other mobile device <collect-install>`
-- :doc:`Installing Aggregate on a server <aggregate-install>`
-
-While this is the *typical* use pattern, it is not the only way to do things. ODK is a very flexible set of tools, and organizations will find their own best practices for adopting it.
-
 
 .. toctree::
   :maxdepth: 1


### PR DESCRIPTION
Makes progress towards #1221 by making Central the recommended server across the documentation.

I tried to keep my changes non-structural and non-controversial. My goal is to first make this relatively surgical change and then to come back as the website project comes together to make sure that the framing is consistent across both resources. There are lots of changes to flow or topic ordering that I was tempted to make but I held back for now hoping that it will make this PR easier to review.

I believe that this change can be merged immediately. It should not affect anyone's existing links and it still makes all of the Aggregate documentation available. 

I'd like to put a warning banner on all of the Aggregate docs. Currently it's only on the intro page. If others find the warning ok, I can put it on every Aggregate page:
<img width="724" alt="Screen Shot 2020-08-01 at 10 31 41 AM" src="https://user-images.githubusercontent.com/967540/89106946-3399ab80-d3e2-11ea-82f3-f499dde559f1.png">

There are changes in several places so I think it's important to look at the diff. Here are a few highlights and what they look like rendered:

**Index**
<img width="655" alt="Screen Shot 2020-08-01 at 10 23 41 AM" src="https://user-images.githubusercontent.com/967540/89107001-a440c800-d3e2-11ea-81f0-7f2214ed38d5.png">

**Central intro**
<img width="741" alt="Screen Shot 2020-08-01 at 10 24 10 AM" src="https://user-images.githubusercontent.com/967540/89106978-85dacc80-d3e2-11ea-85b7-3d4bf97e3208.png">
...
<img width="729" alt="Screen Shot 2020-08-01 at 10 25 58 AM" src="https://user-images.githubusercontent.com/967540/89106977-7c516480-d3e2-11ea-90fa-04cae1083b91.png">

CC @matthew-white @issa-tseng @danbjoseph 