### PR TITLE
update documentation on date function

### DIFF
--- a/odk1-src/form-operators-functions.rst
+++ b/odk1-src/form-operators-functions.rst
@@ -677,7 +677,7 @@ Converting dates and time
 
 .. function:: date(days)
 
-  Converts an integer representing a number of :arg:`days` from January 1, 1970 (the `Unix Epoch`_) to a standard date value.
+  Converts an integer representing a number of :arg:`days` from January 1, 1970 (the `Unix Epoch`_) or a string in ISO 8601 format to a standard date value.
 
   .. _Unix Epoch: https://en.wikipedia.org/wiki/Unix_time
     


### PR DESCRIPTION
### What is included in this PR?

Updates documentation on `date` function to match that it also accepts a string in ISO-8601 based on the comment by @yanokwa in https://forum.getodk.org/t/constraint-on-date/6355/2