### PR TITLE
Update ODK Central install docs on db with SSL

### DIFF
--- a/odk1-src/central-install-digital-ocean.rst
+++ b/odk1-src/central-install-digital-ocean.rst
@@ -292,6 +292,8 @@ ODK Central ships with a PostgreSQL database server. To use your own custom data
     CREATE EXTENSION IF NOT EXISTS pg_trgm;
 
 4. Edit the file ``files/service/config.json.template`` to reflect your database host, table, and authentication details.
+The key `"ssl": {"rejectUnauthorized": false}` is only required if the external database requires TLS/SSL 
+(see [node-postgres docs](https://node-postgres.com/features/ssl)), otherwise it can be omitted.
 
   .. code-block:: console
 
@@ -299,7 +301,8 @@ ODK Central ships with a PostgreSQL database server. To use your own custom data
       "host": "my-db-host",
       "user": "my-db-user",
       "password": "my-db-password",
-      "database": "my-db-table"
+      "database": "my-db-name",
+      "ssl": {"rejectUnauthorized": false}
     },
 
 5. Build and run: ``docker-compose build service``, ``docker-compose stop service``, ``docker-compose up -d service``.


### PR DESCRIPTION
See https://github.com/getodk/docs/issues/1250
Add the magic incantation to allow using a custom db with SSL.
Minor edit: database placeholder uses "my-db-name" in line with postgres terminology (and node-postgres docs).

closes https://github.com/getodk/docs/issues/1250


#### What is included in this PR?
Updated wording in one paragraph in the docs.

#### What new issues will need to be opened because of this PR?
None.

#### What is left to be done in the addressed issue?
Merge.

#### What problems did you encounter?
https://github.com/getodk/central/issues/96

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getodk/docs/1251)
<!-- Reviewable:end -->
