### PR TITLE
Describe limited support for Central on environments other than DO

### DIFF
--- a/odk1-src/central-install-digital-ocean.rst
+++ b/odk1-src/central-install-digital-ocean.rst
@@ -152,6 +152,9 @@ Once you do see it working, you'll want to set up your first Administrator accou
 
 Once you have one account, you do not have to go through this process again for future accounts: you can log into the website with your new account, and directly create new users that way.
 
+.. tip::
+  If you find that users are not receiving emails, read about :ref:`troubleshooting emails <troubleshooting-emails>`.
+
 .. _central-install-digital-ocean-monitoring:
 
 Setting Up Monitoring

--- a/odk1-src/central-install.rst
+++ b/odk1-src/central-install.rst
@@ -31,7 +31,7 @@ Installing elsewhere
 If you got excited when you saw mention of Docker above, and you already have your own destination and process for managing Docker deployments, you're all set to go. ODK Central is entirely defined via **Docker Compose**, which means the ``docker-compose`` command will be all you need to manage the entire system.
 
 .. note::
-  We verify each version of Central on Digital Ocean and confirm that upgrades are possible. However, we do not verify them on other cloud providers and generally can't provide community support for installations that deviate from our basic instructions. You may find other community members able to help `on the forum <https://forum.getodk.org/tag/odk-central>`_.
+  We verify each version of Central on DigitalOcean and confirm that upgrades are possible. However, we do not verify them on other cloud providers and generally can't provide free support for installations that deviate from the DigitalOcean instructions. You may find other community members able to help `on the forum <https://forum.getodk.org/>`_.
 
 No matter where you plan to install Central, we recommend reviewing the :doc:`instructions we've provided <central-install-digital-ocean>` for DigitalOcean starting from :ref:`this section <central-install-digital-ocean-build>`. In particular, you'll need to update your submodules after you clone the repository, and configure your :file:`.env` file for your installation.
 
@@ -39,9 +39,6 @@ Installing on Amazon EC2
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 Amazon Web Services (AWS) is one of the many other options for installing Central. It's a good idea to read through the :doc:`instructions we've provided <central-install-digital-ocean>` for DigitalOcean, as many of the steps remain the same or similar.
-
-.. note::
-  We verify each version of Central on Digital Ocean and confirm that upgrades are possible. However, we do not verify them on other cloud providers and generally can't provide community support for installations that deviate from our basic instructions. You may find other community members able to help `on the forum <https://forum.getodk.org/tag/odk-central>`_.
 
 To obtain a server you will need to first `create an AWS account <https://aws.amazon.com/>`_. When launching your instance, select the Ubuntu Server 16.04 LTS Amazon Machine Image (AMI) in step 1. The ``t2.micro`` instance type has the 1GB of memory recommended for if you don't expect many forms to be submitted at once and you don't expect many large media attachments. When adjusting the security settings open up the ports for SSH, HTTP, and HTTPS. Once you have launched your instance, go to the Elastic IPs menu option under Network & Security, then allocate a new address and associate it with your server in order to keep the IP address for your server consistent. 
 

--- a/odk1-src/central-install.rst
+++ b/odk1-src/central-install.rst
@@ -3,7 +3,7 @@
 Installing ODK Central
 ======================
 
-Unlike ODK Aggregate, Central does not run on Google App Engine. Instead, it is built on a new technology called `Docker <https://en.wikipedia.org/wiki/Docker_(software)>`_, which is a new kind of virtual machine (VM) system that allows smaller image files, better performance, and better ways to define how different pieces should fit together to create a server like Central. Don't worry if you don't know what that means! We have put together step-by-step instructions for our recommended solutions below:
+Central is distributed and installed using `Docker <https://en.wikipedia.org/wiki/Docker_(software)>`_. Docker makes it possible to describe exactly how Central's different components should be configured no matter where it is installed. Don't worry if you don't know about Docker yet! We have put together step-by-step instructions for our recommended solutions below:
 
 .. _central-install-sandbox:
 
@@ -19,7 +19,7 @@ Otherwise, join the `ODK Forum <https://forum.getodk.org>`_ and send a personal 
 Installing on DigitalOcean
 --------------------------
 
-If you want your own server but you're not sure what to do, we recommend installing ODK Central on DigitalOcean, which provides an excellent starting point for Docker installations like ours. For most projects, the $5/month tier will be more than enough for your needs.
+If you want your own server but you're not sure what to do, we recommend installing ODK Central on DigitalOcean, which provides an excellent starting point for Docker installations like ours. The $5/month tier will be enough for most projects (see :ref:`performance notes <central-performance>`).
 
 To learn more about installing on DigitalOcean, please see :doc:`here <central-install-digital-ocean>`.
 
@@ -28,18 +28,26 @@ To learn more about installing on DigitalOcean, please see :doc:`here <central-i
 Installing elsewhere
 --------------------
 
-If you got excited when you heard mention of Docker above, and you already have your own destination and process for managing Docker deployments, you're all set to go. ODK Central is entirely defined via **Docker Compose**, which means the ``docker-compose`` command will be all you need to manage the entire system.
+If you got excited when you saw mention of Docker above, and you already have your own destination and process for managing Docker deployments, you're all set to go. ODK Central is entirely defined via **Docker Compose**, which means the ``docker-compose`` command will be all you need to manage the entire system.
 
-We would still recommend reviewing the :doc:`instructions we've provided <central-install-digital-ocean>` for DigitalOcean starting from :ref:`this section <central-install-digital-ocean-build>`. In particular, you'll need to update your submodules after you clone the repository, and configure your :file:`.env` file for your installation.
+.. note::
+  We verify each version of Central on Digital Ocean and confirm that upgrades are possible. However, we do not verify them on other cloud providers and generally can't provide community support for installations that deviate from our basic instructions. You may find other community members able to help `on the forum <https://forum.getodk.org/tag/odk-central>`_.
+
+No matter where you plan to install Central, we recommend reviewing the :doc:`instructions we've provided <central-install-digital-ocean>` for DigitalOcean starting from :ref:`this section <central-install-digital-ocean-build>`. In particular, you'll need to update your submodules after you clone the repository, and configure your :file:`.env` file for your installation.
 
 Installing on Amazon EC2
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 Amazon Web Services (AWS) is one of the many other options for installing Central. It's a good idea to read through the :doc:`instructions we've provided <central-install-digital-ocean>` for DigitalOcean, as many of the steps remain the same or similar.
 
+.. note::
+  We verify each version of Central on Digital Ocean and confirm that upgrades are possible. However, we do not verify them on other cloud providers and generally can't provide community support for installations that deviate from our basic instructions. You may find other community members able to help `on the forum <https://forum.getodk.org/tag/odk-central>`_.
+
 To obtain a server you will need to first `create an AWS account <https://aws.amazon.com/>`_. When launching your instance, select the Ubuntu Server 16.04 LTS Amazon Machine Image (AMI) in step 1. The ``t2.micro`` instance type has the 1GB of memory recommended for if you don't expect many forms to be submitted at once and you don't expect many large media attachments. When adjusting the security settings open up the ports for SSH, HTTP, and HTTPS. Once you have launched your instance, go to the Elastic IPs menu option under Network & Security, then allocate a new address and associate it with your server in order to keep the IP address for your server consistent. 
 
-Before installing ODK Central on your server, you need to you need to install software dependencies. Install Docker. Steps 1 and 2 of this `how to install Docker on Ubuntu 16.04 tutorial <https://www.digitalocean.com/community/tutorials/how-to-install-and-use-docker-on-ubuntu-16-04>`_ should walk you through the necessary commands. In step 2 add the ``ubuntu`` user to the docker group. You also need to install Docker Compose. This `how to install Docker Compose on Ubuntu 16.04 tutorial <https://www.digitalocean.com/community/tutorials/how-to-install-docker-compose-on-ubuntu-16-04>`_ should walk you through the necessary commands. You should only need to complete step 1. You can change the version number to ``1.24.1``.
+Before installing ODK Central on your server, you need to install software dependencies. Install Docker. Steps 1 and 2 of this `how to install Docker on Ubuntu 16.04 tutorial <https://www.digitalocean.com/community/tutorials/how-to-install-and-use-docker-on-ubuntu-16-04>`_ should walk you through the necessary commands. In step 2 add the ``ubuntu`` user to the docker group. You also need to install Docker Compose. This `how to install Docker Compose on Ubuntu 16.04 tutorial <https://www.digitalocean.com/community/tutorials/how-to-install-docker-compose-on-ubuntu-16-04>`_ should walk you through the necessary commands. You should only need to complete step 1. You can change the version number to ``1.24.1``.
 
 After installing Docker and Docker Compose you can follow our DigitalOcean instructions from running ``git clone https://github.com/getodk/central``. Continue with the DigitalOcean instructions for logging into ODK Central.
 
+.. warning::
+  You will need to :ref:`configure an e-mail service <central-install-digital-ocean-custom-mail>` such as `Amazon SES <https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html>`_ or `SendGrid <https://sendgrid.com/>`_ because Amazon restricts email sent from EC2.

--- a/odk1-src/central-install.rst
+++ b/odk1-src/central-install.rst
@@ -50,4 +50,4 @@ Before installing ODK Central on your server, you need to install software depen
 After installing Docker and Docker Compose you can follow our DigitalOcean instructions from running ``git clone https://github.com/getodk/central``. Continue with the DigitalOcean instructions for logging into ODK Central.
 
 .. warning::
-  You will need to :ref:`configure an e-mail service <central-install-digital-ocean-custom-mail>` such as `Amazon SES <https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html>`_ or `SendGrid <https://sendgrid.com/>`_ because Amazon restricts email sent from EC2.
+  You will need to :ref:`configure an e-mail service <central-install-digital-ocean-custom-mail>` such as `Amazon SES <https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html>`_ or `Mailgun <https://www.mailgun.com/smtp/>`_ because Amazon restricts email sent from EC2.

--- a/odk1-src/central-intro.rst
+++ b/odk1-src/central-intro.rst
@@ -12,7 +12,7 @@ Our goal with Central is to create a server that is straightforward to install, 
 ODK Central Features
 --------------------
 
-We have a lot of exciting ideas for the future of Central, and we look forward to hearing yours as well. Here are the features we already support today:
+Here are some of the major features we support today:
 
  - User accounts and management
  - Role-based user permissioning
@@ -37,8 +37,9 @@ We have a lot of exciting ideas for the future of Central, and we look forward t
 Here are some (but not all) key features we **do not yet** support:
 
  - Customizable user roles
+ - Submission edits
 
-See `What is coming in Central <https://forum.getodk.org/t/whats-coming-in-central-over-the-next-few-years/19677>`_ for more on future features.
+Central is in active development. We have a lot of exciting ideas for its future and we look forward to hearing yours as well. See `What is coming in Central <https://forum.getodk.org/t/whats-coming-in-central-over-the-next-few-years/19677>`_ for more on future direction.
 
 .. _central-intro-who:
 

--- a/odk1-src/central-setup.rst
+++ b/odk1-src/central-setup.rst
@@ -9,4 +9,4 @@ Setting Up ODK Central
   central-command-line
   central-upgrade
   central-backup
-
+  central-troubleshooting

--- a/odk1-src/central-troubleshooting.rst
+++ b/odk1-src/central-troubleshooting.rst
@@ -1,0 +1,21 @@
+.. _central-troubleshooting:
+
+Troubleshooting Central 
+=========================
+
+.. _email-failures:
+
+Users aren't receiving Central emails
+--------------------------------------
+
+Central uses email as a way to verify user identity when setting or changing passwords. This is security best practice and helps ensure that only the intended user has access to their Central account.
+
+Email sounds like a simple technology but in practice there are many things that can cause message delivery issues. By default, Central is installed with a mail server which can be used without configuration. However, it will not work in every environment. For example:
+
+* Many cloud providers such as Amazon restrict the usage of simple mail servers such as Central's as a spam-prevention strategy
+* You can be assigned an IP address that was previously used for sending spam and is therefore blocked by many mail recipients
+* Your domain may not be recognized by mail recipients and therefore messages from it may be discarded or marked as spam
+
+To address delivery issues, consider using a dedicated email service such as `Mailgun <https://www.mailgun.com/smtp/>`_. Because Central doesn't send very many emails, using such a service will generally be a cost-effective way of ensuring email delivery. Once you have an account set up, you will need to :ref:`configure Central to use it <central-install-digital-ocean-custom-mail>`.
+
+If you want to directly send emails from your Central installation, the free `mail-tester <https://www.mail-tester.com/>`_ service can help you identify what barriers to email delivery you might have. Create a Central account with the email address that it provides, retrieve your results, and then delete the user. Typically, the first thing you will need to do is :ref:`configure DKIM <central-install-digital-ocean-dkim>` which will provide email recipients confidence that emails were actually sent by your Central server rather than by a spammer pretending to be your server.

--- a/odk1-src/central-troubleshooting.rst
+++ b/odk1-src/central-troubleshooting.rst
@@ -3,19 +3,19 @@
 Troubleshooting Central 
 =========================
 
-.. _email-failures:
+.. _troubleshooting-emails:
 
 Users aren't receiving Central emails
 --------------------------------------
 
-Central uses email as a way to verify user identity when setting or changing passwords. This is security best practice and helps ensure that only the intended user has access to their Central account.
+Central uses email as a way to verify user identity when setting or changing passwords. This helps ensure that only the intended user has access to their Central account.
 
 Email sounds like a simple technology but in practice there are many things that can cause message delivery issues. By default, Central is installed with a mail server which can be used without configuration. However, it will not work in every environment. For example:
 
-* Many cloud providers such as Amazon restrict the usage of simple mail servers such as Central's as a spam-prevention strategy
+* Many cloud providers restrict the usage of simple mail servers such as Central's as a spam-prevention strategy
 * You can be assigned an IP address that was previously used for sending spam and is therefore blocked by many mail recipients
 * Your domain may not be recognized by mail recipients and therefore messages from it may be discarded or marked as spam
 
 To address delivery issues, consider using a dedicated email service such as `Mailgun <https://www.mailgun.com/smtp/>`_. Because Central doesn't send very many emails, using such a service will generally be a cost-effective way of ensuring email delivery. Once you have an account set up, you will need to :ref:`configure Central to use it <central-install-digital-ocean-custom-mail>`.
 
-If you want to directly send emails from your Central installation, the free `mail-tester <https://www.mail-tester.com/>`_ service can help you identify what barriers to email delivery you might have. Create a Central account with the email address that it provides, retrieve your results, and then delete the user. Typically, the first thing you will need to do is :ref:`configure DKIM <central-install-digital-ocean-dkim>` which will provide email recipients confidence that emails were actually sent by your Central server rather than by a spammer pretending to be your server.
+If you want to directly send emails from your Central installation, the `mail-tester <https://www.mail-tester.com/>`_ service can help you identify what barriers to email delivery you might have. Create a Central account with the email address that it provides, retrieve your results, and then delete the user. Typically, the first thing you will need to do is :ref:`configure DKIM <central-install-digital-ocean-dkim>` which will provide email recipients confidence that emails were actually sent by your Central server rather than by a spammer pretending to be your server.


### PR DESCRIPTION
We need to be explicit that the core team has limited ability to verify Central releases on platforms other than Digital Ocean and that we generally won't be able to provide free support for custom installs.

I tried to make the message direct but still friendly. I went with "community support" but also considered "free support". I considered saying "because Central is developed by a small team" or something like that but it didn't seem all that useful.