### PR TITLE
Remove sandboxes, add ODK cloud, remove extra ODKs

### DIFF
--- a/odk1-src/aggregate-app-engine-legacy.rst
+++ b/odk1-src/aggregate-app-engine-legacy.rst
@@ -77,8 +77,6 @@ For most users, Google App Engine will be the easiest and most cost-effective op
 
 Two examples illustrate the cost-effectiveness of Google App Engine:
 
-- The fee to run the `ODK Aggregate Demo Server <http://opendatakit.appspot.com>`_ is near the minimum weekly charge, costing a few dollars a week.
-
 - A 6000 hour study in Mumbai that ran from 01 September 2011 through 29 February 2012 also incurred the minimum charge of $2.10/week for mid-November onward (Google did not begin billing until mid November 2011).
 
 You can enable billing on an as-needed weekly basis. You will incur no charges at all if you disable billing (for example, between data gathering campaigns, while you are developing the forms for the next campaign). When disabled, access is restricted to the free daily usage limit.

--- a/odk1-src/aggregate-setup.rst
+++ b/odk1-src/aggregate-setup.rst
@@ -4,11 +4,6 @@ Setting Up ODK Aggregate
 .. warning::
   Aggregate is no longer actively developed. Please use :doc:`ODK Central <central-intro>` instead.
 
-.. admonition:: Before you get started
-  
-  If you just want to explore ODK Aggregate, try the `demo server <https://opendatakit.appspot.com>`_.
-
-
 .. toctree::
   :maxdepth: 2
   

--- a/odk1-src/central-api.rst
+++ b/odk1-src/central-api.rst
@@ -1,9 +1,9 @@
 .. _central-api:
 
-Using the ODK Central REST API
-==============================
+Using the Central REST API
+==========================
 
-We provide a fully featured REST API for ODK Central. In fact, everything the Central management website does is over the REST API, so everything it can do you can, too: creating users and forms, managing app users, and so on. We also provide compliant standard APIs for OpenRosa and OData.
+We provide a fully featured REST API for Central. In fact, everything the Central management website does is over the REST API, so everything it can do you can, too: creating users and forms, managing app users, and so on. We also provide compliant standard APIs for OpenRosa and OData.
 
-For more information on using the ODK Central APIs, please visit our `developer documentation <https://odkcentral.docs.apiary.io/#>`_.
+For more information on using the Central APIs, please visit our `developer documentation <https://odkcentral.docs.apiary.io/#>`_.
 

--- a/odk1-src/central-command-line.rst
+++ b/odk1-src/central-command-line.rst
@@ -1,9 +1,9 @@
 .. _central-command-line:
 
-ODK Central Command Line Tools
-==============================
+Central Command Line Tools
+==========================
 
-ODK Central allows some administrative actions to be performed by anybody with direct console access to the server itself. Usually, this means only the person who set up the server and installed Central onto it. These tools can be used to:
+Central allows some administrative actions to be performed by anybody with direct console access to the server itself. Usually, this means only the person who set up the server and installed Central onto it. These tools can be used to:
 
  - create new user accounts,
  - reset passwords,
@@ -60,7 +60,7 @@ You will be prompted for a new password. Type it in and press Enter, and if you 
 Promoting a Web User to administrator by command line
 -----------------------------------------------------
 
-In the current release of ODK Central, all users created by the website interface are automatically administrators. If you create a user using the ``user-create`` tool shown above, however, you'll have to perform that step manually. If you do not, the user will be unable to do much of anything at all once they log in.
+In the current release of Central, all users created by the website interface are automatically administrators. If you create a user using the ``user-create`` tool shown above, however, you'll have to perform that step manually. If you do not, the user will be unable to do much of anything at all once they log in.
 
 Please start by performing the steps above in the :ref:`central-command-line-basics` section. Once you do, here is what you would type, assuming the email address of the account you wish to make an administrator is ``example@getodk.org``:
 

--- a/odk1-src/central-install-digital-ocean.rst
+++ b/odk1-src/central-install-digital-ocean.rst
@@ -14,8 +14,8 @@ In general, this installation process will involve five phases:
 
 1. Obtaining a server and loading it with the appropriate base system.
 2. Obtaining a web address (domain name) and pointing it at your new server.
-3. Obtaining the ODK Central software and installing it on your server.
-4. Preparing ODK Central for startup and running it for the first time.
+3. Obtaining the Central software and installing it on your server.
+4. Preparing Central for startup and running it for the first time.
 5. Creating your first Central Administrator account and logging into it.
 
 There are also some optional other steps you can take, which you can find at the bottom of this page.
@@ -57,7 +57,7 @@ Obtaining a Web Address (Domain Name)
 
 Now is the time to set up a domain name. We will do so, and then configure it so that it sends users to the server you created in the previous step.
 
-You'll need to do this for two reasons: a memorable name (like ``google.com``) will be easier to remember and access than a pile of numbers, and you cannot obtain a security certificate without one. It is not currently possible to host ODK Central within a subdirectory on another domain (so, ``my-website.com/my-odk-server`` is not possible, but ``my-odk-server.com`` is allowed, as is ``my-odk-server.my-website.com``).
+You'll need to do this for two reasons: a memorable name (like ``google.com``) will be easier to remember and access than a pile of numbers, and you cannot obtain a security certificate without one. It is not currently possible to host Central within a subdirectory on another domain (so, ``my-website.com/my-odk-server`` is not possible, but ``my-odk-server.com`` is allowed, as is ``my-odk-server.my-website.com``).
 
 If you already know how to do these sorts of things, feel free to ignore the following instructions and proceed on your own. You can rejoin us at the next section.
 
@@ -72,10 +72,10 @@ New domain names take a little bit to get working. Meanwhile, we can get working
 
 .. _central-install-digital-ocean-build:
 
-Installing ODK Central
-----------------------
+Installing Central
+------------------
 
-In this phase of installation, we will log into your new server, obtain the ODK Central software, load some settings into it, and install it.
+In this phase of installation, we will log into your new server, obtain the Central software, load some settings into it, and install it.
 
 First, you'll need to be able to log into the server itself. If you are an advanced user who filled in an SSH key above, you're good to go. Otherwise, click your email for a message from DigitalOcean with your server password.
 
@@ -100,10 +100,10 @@ The quickest way to do this is to run ``ufw disable`` while logged into your ser
 
   If you don't want to disable the firewall entirely, you can instead configure Docker, ``iptables``, and ``ufw`` yourself. This can be really difficult to do correctly, so we don't recommend most people try. Another option is to use an upstream network firewall.
 
-  The goal here is to ensure that it is possible to access the host through its external IP from within each Docker container. In particular, if you can successfully ``curl`` your ODK Central website over HTTPS on its public domain name, all Enketo features should work correctly.
+  The goal here is to ensure that it is possible to access the host through its external IP from within each Docker container. In particular, if you can successfully ``curl`` your Central website over HTTPS on its public domain name, all Enketo features should work correctly.
 
-Obtaining and Setting Up ODK Central
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Obtaining and Setting Up Central
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Now you'll need to download the software. In the server window, type ``git clone https://github.com/getodk/central`` and press **Enter**. It should think for some time and download many things. Then type ``cd central`` to start working with the software.
 
@@ -122,26 +122,26 @@ Next, you need to update some settings. Type ``nano .env`` and press **Enter**. 
 
 Now, we will bundle everything together into a server. Type ``docker-compose build`` and press **Enter** to do this. This will take a long time and generate quite a lot of text output. Don't worry if it seems to pause without saying anything for a while. When it finishes, you should see some "Successfully built" type text and get your input prompt back. When that happens, type ``docker-compose up --no-start`` and press **Enter**.
 
-Once that is complete, congratulations! You have installed your copy of ODK Central. Next, we need to teach the server how to start it up, and do so.
+Once that is complete, congratulations! You have installed your copy of Central. Next, we need to teach the server how to start it up, and do so.
 
 .. _central-install-digital-ocean-startup:
 
-Starting up ODK Central
------------------------
+Starting up Central
+-------------------
 
 Now, run ``docker-compose up -d`` to start the server software. The first time you start it, it will take a while to set itself up. Once you give it a few minutes and you have input control again, you'll want to see whether everything is running correctly:
 
  - To see if ODK has finished loading, run ``docker-compose ps``. Under the ``State`` column, you will want to see text that reads ``Up (healthy)``. If you see ``Up (health: starting)``, give it a few minutes. If you see some other text, something has gone wrong.
- - If your domain name has started working, you can visit it in a web browser to check that you get the ODK Central management website.
+ - If your domain name has started working, you can visit it in a web browser to check that you get the Central management website.
 
 You're almost done! All you have to do is create an Administrator account so that you can log into Central.
 
 .. _central-install-digital-ocean-account:
 
-Logging into ODK Central
-------------------------
+Logging into Central
+--------------------
 
-If visiting your server domain name address in your browser does not load the ODK Central management website, you may have to wait a few minutes or hours (possibly even a day) for the domain name itself to get working. These instructions are explained in further depth on the page detailing the :doc:`central-command-line`.
+If visiting your server domain name address in your browser does not load the Central management website, you may have to wait a few minutes or hours (possibly even a day) for the domain name itself to get working. These instructions are explained in further depth on the page detailing the :doc:`central-command-line`.
 
 Once you do see it working, you'll want to set up your first Administrator account. To do this:
 
@@ -168,7 +168,7 @@ We strongly recommend creating an alert for Disk Utilization. A threshold of 90%
 
 If you are familiar with server operations, you may wish to set up some other alerts: CPU usage and Memory Utilization are the most interesting remaining metrics. However, these are not as important or easily understandable as the Disk Utilization alert, so you may skip this if you're not sure what to do here.
 
-You're done! Congratulations. In the future, you may wish to consult the :doc:`central-upgrade` guide, but for now you may begin using ODK Central. The :doc:`central-using` sections can help you with your next steps if you aren't sure how to proceed.
+You're done! Congratulations. In the future, you may wish to consult the :doc:`central-upgrade` guide, but for now you may begin using Central. The :doc:`central-using` sections can help you with your next steps if you aren't sure how to proceed.
 
 .. _central-install-digital-ocean-advanced:
 
@@ -234,7 +234,7 @@ Log into your server so you have a console prompt, and run these commands, adapt
 Using a Custom SSL Certificate
 ------------------------------
 
-By default, ODK Central uses Let's Encrypt to obtain an SSL security certificate. For most users, this should work perfectly, but larger managed internal networks may have their own certificate trust infrastructure. To use your own custom SSL certificate rather than the automatic Let's Encrypt system:
+By default, Central uses Let's Encrypt to obtain an SSL security certificate. For most users, this should work perfectly, but larger managed internal networks may have their own certificate trust infrastructure. To use your own custom SSL certificate rather than the automatic Let's Encrypt system:
 
 1. Generate a ``fullchain.pem`` (``-out``) file which contains your certificate followed by any necessary intermediate certificate(s).
 2. Generate a ``privkey.pem`` (``-keyout``) file which contains the private key used to sign your certificate.
@@ -247,7 +247,7 @@ By default, ODK Central uses Let's Encrypt to obtain an SSL security certificate
 Using a Custom Mail Server
 --------------------------
 
-ODK Central ships with a basic EXIM server bundled to forward mail out to the internet. To use your own custom mail server:
+Central ships with a basic EXIM server bundled to forward mail out to the internet. To use your own custom mail server:
 
 1. Ensure you have an SMTP relay server visible to your Central server network host.
 2. Edit the file ``files/service/config.json.template`` to reflect your network hostname, the TCP port, and authentication details. The ``secure`` flag is for TLS and should be set to ``true`` if the port is 465 and ``false`` for other ports. If no authentication is required, remove the ``auth`` section.
@@ -278,7 +278,7 @@ Using a Custom Database Server
 .. warning::
   Using a custom database server, especially one that is not local to your local network, may result in poor performance. We strongly recommend using the Postgres v9.6 server that is bundled with Central.
 
-ODK Central ships with a PostgreSQL database server. To use your own custom database server:
+Central ships with a PostgreSQL database server. To use your own custom database server:
 
 1. Ensure you have a PostgresSQL database server visible to your Central server network host.
 2. Ensure your database has ``UTF8`` encoding by running the following command on the database.
@@ -312,7 +312,7 @@ ODK Central ships with a PostgreSQL database server. To use your own custom data
 Disabling or Customizing Sentry
 -------------------------------
 
-By default, we enable `Sentry error logging <https://sentry.io>`_ on the backend server, which provides the ODK Central development team with an anonymized log of unexpected programming errors that occur while your server is running. This information is only visible to the development team and should never contain any of your user or form data, but if you feel uncomfortable with this anyway, you can take the following steps to disable Sentry:
+By default, we enable `Sentry error logging <https://sentry.io>`_ on the backend server, which provides the Central development team with an anonymized log of unexpected programming errors that occur while your server is running. This information is only visible to the development team and should never contain any of your user or form data, but if you feel uncomfortable with this anyway, you can take the following steps to disable Sentry:
 
 1. Edit the file ``files/service/config.json.template`` and remove the ``sentry`` lines, starting with ``"sentry": {`` through the next three lines until you remove the matching ``}``.
 2. Build and run: ``docker-compose build service``, ``docker-compose stop service``, ``docker-compose up -d service``.

--- a/odk1-src/central-install.rst
+++ b/odk1-src/central-install.rst
@@ -1,25 +1,19 @@
 .. _central-install:
 
-Installing ODK Central
-======================
+Installing Central
+==================
 
-Central is distributed and installed using `Docker <https://en.wikipedia.org/wiki/Docker_(software)>`_. Docker makes it possible to describe exactly how Central's different components should be configured no matter where it is installed. Don't worry if you don't know about Docker yet! We have put together step-by-step instructions for our recommended solutions below:
+Central is distributed and installed using `Docker <https://en.wikipedia.org/wiki/Docker_(software)>`_. Docker makes it possible to describe exactly how Central's different components should be configured no matter where it is installed. Don't worry if you don't know about Docker yet! We have put together step-by-step instructions for our recommended solutions below.
 
-.. _central-install-sandbox:
+Using ODK Cloud (recommended)
+-----------------------------
 
-Using the Sandbox
------------------
-
-If you only want to try ODK Central to see if it's suitable for your project, consider skipping installation altogether and using the `Sandbox installation <https://sandbox.central.getodk.org/>`_ we've provided for exactly this reason. Do note that since there is only one Sandbox, all Sandbox users will be able to see each others' email addresses, form definitions, and submission data, so please be careful if you have sensitive information you wish to keep secret.
-
-Otherwise, join the `ODK Forum <https://forum.getodk.org>`_ and send a personal message to `@yanokwa <https://forum.getodk.org/u/yanokwa>`_ to gain access to the Sandbox.
-
-.. _central-install-docker:
+The easiest way to get a Central server is by using `ODK Cloud <https://getodk.org/#odk-cloud>`_. ODK Cloud provides Central servers that are fully managed and supported by ODK. No technical knowledge is required.
 
 Installing on DigitalOcean
 --------------------------
 
-If you want your own server but you're not sure what to do, we recommend installing ODK Central on DigitalOcean, which provides an excellent starting point for Docker installations like ours. The $5/month tier will be enough for most projects (see :ref:`performance notes <central-performance>`).
+If you want to install Central on own server but you're not sure what cloud provider to choose, we recommend DigitalOcean, which provides an excellent starting point for Docker installations like ours. The $5/month tier will be enough for most projects (see :ref:`performance notes <central-performance>`).
 
 To learn more about installing on DigitalOcean, please see :doc:`here <central-install-digital-ocean>`.
 
@@ -28,7 +22,7 @@ To learn more about installing on DigitalOcean, please see :doc:`here <central-i
 Installing elsewhere
 --------------------
 
-If you got excited when you saw mention of Docker above, and you already have your own destination and process for managing Docker deployments, you're all set to go. ODK Central is entirely defined via **Docker Compose**, which means the ``docker-compose`` command will be all you need to manage the entire system.
+If you got excited when you saw mention of Docker above, and you already have your own destination and process for managing Docker deployments, you're all set to go. Central is entirely defined via **Docker Compose**, which means the ``docker-compose`` command will be all you need to manage the entire system.
 
 .. warning::
   We verify each version of Central on DigitalOcean and confirm that upgrades are possible. However, we do not verify them on other cloud providers and generally can't provide free support for installations that deviate from the DigitalOcean instructions. You may find other community members able to help `on the forum <https://forum.getodk.org/>`_.
@@ -44,12 +38,12 @@ To obtain a server you will need to first `create an AWS account <https://aws.am
 
 When adjusting the security settings open up the ports for SSH, HTTP, and HTTPS. Once you have launched your instance, go to the Elastic IPs menu option under Network & Security, then allocate a new address and associate it with your server in order to keep the IP address for your server consistent.
 
-Before installing ODK Central on your server, you need to install Docker and Docker Compose.
+Before installing Central on your server, you need to install Docker and Docker Compose.
 
 1. Docker. Steps 1 and 2 of this `how to install Docker on Ubuntu 16.04 tutorial <https://www.digitalocean.com/community/tutorials/how-to-install-and-use-docker-on-ubuntu-16-04>`_ should walk you through the necessary commands. In step 2 add the ``ubuntu`` user to the Docker group.
 
 2. Docker Compose. This `how to install Docker Compose on Ubuntu 16.04 tutorial <https://www.digitalocean.com/community/tutorials/how-to-install-docker-compose-on-ubuntu-16-04>`_ should walk you through the necessary commands. You should only need to complete step 1. You can change the version number to ``1.24.1``.
 
-After installing Docker and Docker Compose you can follow our DigitalOcean instructions from running ``git clone https://github.com/getodk/central``. Continue with the DigitalOcean instructions for logging into ODK Central.
+After installing Docker and Docker Compose you can follow our DigitalOcean instructions from running ``git clone https://github.com/getodk/central``. Continue with the DigitalOcean instructions for logging into Central.
 
 Finally, :ref:`configure an e-mail service <central-install-digital-ocean-custom-mail>` such as `Amazon SES <https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html>`_ because Amazon restricts emails sent from EC2.

--- a/odk1-src/central-upgrade.rst
+++ b/odk1-src/central-upgrade.rst
@@ -7,7 +7,7 @@ We release new versions of Central regularly. You do not have to upgrade to the 
 
 .. admonition:: Note
 
-  You can check your current version by adding ``version.txt`` to the URL. For example `https://sandbox.central.getodk.org/version.txt <https://sandbox.central.getodk.org/version.txt>`_.
+  You can check your current version by adding ``version.txt`` to the URL. For example `https://trial.getodk.cloud/version.txt <https://trial.getodk.cloud/version.txt>`_.
 
 To perform an upgrade, you'll first need to get to the software. You'll need to log into your server's command line prompt again, like you did when you first set up the server. If you used our :doc:`DigitalOcean installation steps <central-install-digital-ocean>` but can't quite remember how to do this, we suggest reviewing the section :ref:`central-install-digital-ocean-build` as a reminder, or if you can't remember your password to start at the top of that section to reset your password.
 
@@ -40,5 +40,5 @@ The quickest way to do this is to run ``ufw disable`` while logged into your ser
 
   If you don't want to disable the firewall entirely, you can instead configure Docker, ``iptables``, and ``ufw`` yourself. This can be really difficult to do correctly, so we don't recommend most people try. Another option is to use an upstream network firewall.
 
-  The goal here is to ensure that it is possible to access the host through its external IP from within each Docker container. In particular, if you can successfully ``curl`` your ODK Central website over HTTPS on its public domain name, all Enketo features should work correctly.
+  The goal here is to ensure that it is possible to access the host through its external IP from within each Docker container. In particular, if you can successfully ``curl`` your Central website over HTTPS on its public domain name, all Enketo features should work correctly.
 

--- a/odk1-src/collect-connect.rst
+++ b/odk1-src/collect-connect.rst
@@ -3,9 +3,9 @@ Connecting to a Server
 
 ODK Collect is used to fill forms with participants. Filled forms then need to be sent to a central location for review and analysis. Generally, organizations do this by configuring Collect to send forms to a server. For those working in environments without any internet connectivity, there are :ref:`other options <other-collect-server-options>`.
 
-When you first install Collect, it connects to `a demo server <https://opendatakit.appspot.com/Aggregate.html>`_. This allows you to try out the app by :ref:`downloading blank example forms <in-app-get-blank-forms>`, :doc:`filling them out <collect-filling-forms>`, and :ref:`uploading completed forms <uploading-forms>` back to the demo server.
+When you first install Collect, it connects to a demo server. This allows you to try out the app by :ref:`downloading blank example forms <in-app-get-blank-forms>`, :doc:`filling them out <collect-filling-forms>`, and :ref:`uploading completed forms <uploading-forms>` back to the demo server.
   
-Once you are done trying out Collect, you will need a plan for managing forms and data submissions. We recommend using :ref:`ODK Central <central-intro>` and configuring Collect by QR code. :doc:`ODK Central <central-intro>` provides user and project management features as well as tools for viewing and exporting data. For complex data collection projects, it is usually the right choice. Organizations can choose to use their own infrastructure and have total control over their server configuration. However, setting up and maintaining a server requires technical skills.
+Once you are done trying out Collect, you will need a plan for managing forms and data submissions. We recommend using :ref:`ODK Central <central-intro>` and configuring Collect by QR code. :doc:`Central <central-intro>` provides user and project management features as well as tools for viewing and exporting data. For complex data collection projects, it is usually the right choice. Organizations can choose to use their own infrastructure and have total control over their server configuration. However, setting up and maintaining a server requires technical skills.
 
 Simple projects can choose to send data directly to Google Sheets.
 

--- a/odk1-src/collect-install.rst
+++ b/odk1-src/collect-install.rst
@@ -3,16 +3,18 @@ Installing Collect
 
 .. _install-collect-from-google-play:
 
-Installing from Google Play Store (**Recommended**)
+Installing from Google Play Store (recommended)
 ----------------------------------------------------
 
-`The ODK Collect App is available in the Google Play store <https://play.google.com/store/apps/details?id=org.odk.collect.android&hl=en>`_.
+ODK Collect is available in the `Google Play Store <https://play.google.com/store/apps/details?id=org.odk.collect.android>`_.
 
 
-Installing Manually
+.. _install-collect-manually:
+
+Installing manually
 -------------------
 
-The Google Play store always has the latest stable release.
+The Google Play Store always has the latest stable release. 
 
 If you need a different version of Collect, you can download from the web and install manually.
 

--- a/odk1-src/getting-started.rst
+++ b/odk1-src/getting-started.rst
@@ -8,29 +8,24 @@ You will:
 .. contents::
  :local:
 
-.. _getting-started-install-collect:
-
-Install Collect
----------------------
-
-The easiest way to install the Collect app is `to get it from the Google Play store <https://play.google.com/store/apps/details?id=org.odk.collect.android&hl=en>`_.
-
-.. seealso:: :doc:`collect-install`
-
 .. _getting-started-install-central:
 
-Install Central
-----------------
+Get a Central server
+--------------------
 
-The easiest way to set up your own Central server is to :doc:`install it on DigitalOcean <central-install-digital-ocean>`, a cloud provider.
+The easiest way to get a Central server is by using `ODK Cloud <https://getodk.org/#odk-cloud>`_. ODK Cloud provides Central servers that are fully managed and supported by ODK. No technical knowledge is required.
 
-If you want to try Central out, you can :ref:`request access to the sandbox <central-install-sandbox>`.
+If you are technical and are interested in self-installing, we recommend you :doc:`install Central on DigitalOcean <central-install-digital-ocean>`.
 
-.. warning::
+.. _getting-started-install-collect:
 
-  The Central sandbox server is for evaluation purposes only. All forms and data on this server are public and may be deleted without notice.
-  
-.. seealso:: :doc:`central-install`
+Get the Collect app
+-------------------
+
+The easiest way to get the Collect app is to download it from the `Google Play Store <https://play.google.com/store/apps/details?id=org.odk.collect.android>`_.
+
+You can also :ref:`install manually <install-collect-manually>` from an APK.
+
 
 .. _getting-started-create-form:
 


### PR DESCRIPTION
* Removed references to the Central and Aggregate sandboxes
* Added language about ODK Cloud and made it an top-level item for visibility
* Flipped order of getting started to start with Central, then Collect
* Cleaned up lots of extra "ODK tool" names
* Cleaned up Play Store links