### PR TITLE
Added warnings to make it clear that we don't support having repeating questions inside field-list groups

### DIFF
--- a/src/form-logic.rst
+++ b/src/form-logic.rst
@@ -583,6 +583,10 @@ You can ask the same question or questions multiple times by wrapping them in :t
   text, fave_color, What is your favorite color?
   end_repeat, , 
 
+.. warning::
+
+  Displaying repeating questions :ref:`on the same screen <field-list>` (inside a :tc:`field-list` group) is not supported.
+
 .. seealso::
     :doc:`form-repeats` describes strategies to address common repetition scenarios.
 

--- a/src/form-question-types.rst
+++ b/src/form-question-types.rst
@@ -2231,6 +2231,10 @@ The :tc:`field-list` appearance attribute, applied to a group of widgets, displa
 
   Relevance, constraint and calculation evaluation within the same screen is supported in Collect v1.22 and later.
 
+.. warning::
+
+  Displaying :ref:`repeats` on the same screen (inside a :tc:`field-list` group) is not supported.
+
 .. seealso::
 
   :ref:`groups` and :ref:`repeats`.


### PR DESCRIPTION
closes #1267


#### What is included in this PR?
I added two warnings in the docs to make it clear that we don't support having repeating questions inside field-list groups