### PR TITLE
Cleanup footer

### DIFF
--- a/src/_templates/footer.html
+++ b/src/_templates/footer.html
@@ -12,14 +12,14 @@
 
   <hr/>
 <p class="footerText"><a href="_downloads/ODK-Documentation.pdf" download>Download this documentation as a PDF.</a></p>
-<p class="footerText">If you still need help, you can ask support questions in the <a href="https://forum.getodk.org/">ODK Forum </a> </p>
+<p class="footerText">If you still need help, you can ask support questions in the <a href="https://forum.getodk.org/">ODK Forum</a>.</p>
   <div role="contentinfo">
     <p>
     {%- if show_copyright %}
       {%- if hasdoc('copyright') %}
         {% trans path=pathto('copyright'), copyright=copyright|e %}&copy; <a href="{{ path }}">Copyright</a> {{ copyright }}.{% endtrans %}
       {%- else %}
-        {% trans copyright=copyright|e %}&copy; Copyright {{ copyright }}.{% endtrans %}
+        {% trans copyright=copyright|e %}&copy; {{ copyright }}.{% endtrans %}
       {%- endif %}
     {%- endif %}
 
@@ -42,10 +42,6 @@
 
     </p>
   </div>
-
-  {%- if show_sphinx %}
-  {% trans %}Built with <a href="http://sphinx-doc.org/">Sphinx</a> using a <a href="https://github.com/snide/sphinx_rtd_theme">theme</a> provided by <a href="https://readthedocs.org">Read the Docs</a>{% endtrans %}.
-  {%- endif %}
 
   {%- block extrafooter %} {% endblock %}
 

--- a/src/_templates/footer.html
+++ b/src/_templates/footer.html
@@ -13,8 +13,6 @@
   <hr/>
 <p class="footerText"><a href="_downloads/ODK-Documentation.pdf" download>Download this documentation as a PDF.</a></p>
 <p class="footerText">If you still need help, you can ask support questions in the <a href="https://forum.getodk.org/">ODK Forum </a> </p>
-<p class="footerText">If you find a problem with this documentation, please <a href="https://github.com/getodk/docs/issues">file an issue </a> </p>
-<p class="footerText">You are also encouraged to <a href="https://github.com/getodk/docs/">fork our Github repo</a> and <a href="contributing/">become a contributor</a></p>
   <div role="contentinfo">
     <p>
     {%- if show_copyright %}

--- a/src/_templates/footer.html
+++ b/src/_templates/footer.html
@@ -11,11 +11,10 @@
   {% endif %}
 
   <hr/>
-  <p class="footerText"> <a href="{{ pathto(odk_pdf, 1) }}" download> {{ download_pdf }} </a></p>
-  <p class="footerText"> {{ faq_help }} <a href="{{ forum_here }}"> {{ forum }} </a> </p>
-  <p class="footerText"> {{ prob_in_doc }} <a href="{{ file_issue_here }}"> {{ file_issue }} </a> </p>
-  <p class="footerText"> {{ contri_start }} <a href="{{ repo_here }}"> {{ fork_repo }} </a> {{ join }} <a href="{{ pathto('contributing') }}"> {{ contri }} </a></p>
-  
+<p class="footerText"><a href="_downloads/ODK-Documentation.pdf" download>Download this documentation as a PDF.</a></p>
+<p class="footerText">If you still need help, you can ask support questions in the <a href="https://forum.getodk.org/">ODK Forum </a> </p>
+<p class="footerText">If you find a problem with this documentation, please <a href="https://github.com/getodk/docs/issues">file an issue </a> </p>
+<p class="footerText">You are also encouraged to <a href="https://github.com/getodk/docs/">fork our Github repo</a> and <a href="contributing/">become a contributor</a></p>
   <div role="contentinfo">
     <p>
     {%- if show_copyright %}

--- a/src/conf.py
+++ b/src/conf.py
@@ -276,78 +276,6 @@ rst_prolog="""
     :class: arg
 """
 
-# At bottom of every document
-download_pdf = """
-
-Download this documentation as a PDF.
-
-"""
-odk_pdf = """
-
-_downloads/ODK-Documentation.pdf
-
-"""
-prob_in_doc = """
-
-If you find a problem with this documentation, please
-
-"""
-file_issue = """
-
-file an issue
-
-"""
-file_issue_here = """
-
-https://github.com/getodk/docs/issues
-
-"""
-contri_start = """
-
-You are also encouraged to
-
-"""
-fork_repo = """
-
-fork our Github repo
-
-"""
-repo_here = """
-
-https://github.com/getodk/docs/
-
-"""
-join = """
-
-and
-
-"""
-contri = """
-
-become a contributor
-
-"""
-contri_guide = """
-
-/contributing/
-
-"""
-faq_help = """
-
-If you still need help, you can ask support questions in the
-
-"""
-forum = """
-
-ODK Forum
-
-"""
-forum_here = """
-
-https://forum.getodk.org/
-
-"""
-
 rst_epilog = """
 
 .. |odk-slack| replace:: ODK Slack
@@ -364,20 +292,7 @@ rst_epilog = """
 
 """
 
-html_context = {'download_pdf' : download_pdf,
-                'odk_pdf' : odk_pdf,
-                'prob_in_doc' : prob_in_doc ,
-                'contri_start' : contri_start ,
-                'join' : join ,
-                'faq_help' : faq_help ,
-                'file_issue' : file_issue ,
-                'fork_repo' : fork_repo ,
-                'contri' : contri ,
-                'forum' : forum ,
-                'file_issue_here' : file_issue_here ,
-                'repo_here' : repo_here ,
-                'contri_guide' : contri_guide ,
-                'forum_here' : forum_here ,
+html_context = {
                 'display_github' : True,
                 'github_user' : "getodk", # Username
                 'github_repo' : "docs", # Repo name

--- a/src/conf.py
+++ b/src/conf.py
@@ -58,7 +58,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'ODK'
-copyright = '2020, ODK. This document is licensed under a Creative Commons Attribution 4.0 International License'
+copyright = '2020 Get ODK Inc. Licensed under CC BY 4.0'
 author = 'ODK'
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
* Simplify the footer structure. Not sure why it is so complex to begin with.
* Reduce the copyright to the bare minimum notice (https://www.copyright.gov/circs/circ03.pdf)
* The theme doesn't require attribution (as determined by skimming https://sphinx-rtd-theme.readthedocs.io/en/latest/index.html and the existence of the show_sphinx variable (which doesn't seem to work)) 