### PR TITLE
[work in progress] docs changes for central v1.1

### DIFF
--- a/src/central-backup.rst
+++ b/src/central-backup.rst
@@ -56,6 +56,15 @@ Setting up backups
 
   You can verify your Google Drive usage `on the Drive storage page <https://drive.google.com/settings/storage>`_. You may want to periodically remove older backups to free up space.
 
+.. _central-backup-immediate:
+
+Performing an immediate backup
+------------------------------
+
+It is possible to immediately download a backup of your database to your own computer. As of Central v1.1, you will still need to have managed backups configured. Once you do, you will see a button :guilabel:`Download Backup Now` next to the :guilabel:`Terminate` button near the top.
+
+Clicking this button will perform an immediate backup and download the result to your computer. This process can take some time, and it is normal for data to download quite slowly for many minutes before it gets faster. Take care in using this feature particularly if you have a lot of data and traffic, as performing a backup while a lot of data is being saved to the database can cause a lot of slowdown.
+
 .. _central-backup-restore:
 
 Restoring a backup

--- a/src/central-install-digital-ocean.rst
+++ b/src/central-install-digital-ocean.rst
@@ -131,7 +131,7 @@ Starting up Central
 
 Now, run ``docker-compose up -d`` to start the server software. The first time you start it, it will take a while to set itself up. Once you give it a few minutes and you have input control again, you'll want to see whether everything is running correctly:
 
- - To see if ODK has finished loading, run ``docker-compose ps``. Under the ``State`` column, you will want to see text that reads ``Up (healthy)``. If you see ``Up (health: starting)``, give it a few minutes. If you see some other text, something has gone wrong.
+ - To see if ODK has finished loading, run ``docker-compose ps``. Under the ``State`` column, for the ``nginx`` row, you will want to see text that reads ``Up`` or ``Up (healthy)``. If you see ``Up (health: starting)``, give it a few minutes. If you see some other text, something has gone wrong. It is normal to see ``Exit 0`` for the ``secrets`` container.
  - If your domain name has started working, you can visit it in a web browser to check that you get the Central management website.
 
 You're almost done! All you have to do is create an Administrator account so that you can log into Central.

--- a/src/central-install-digital-ocean.rst
+++ b/src/central-install-digital-ocean.rst
@@ -185,7 +185,13 @@ Configuring DKIM
 DKIM is a security trust protocol which is used to help verify mail server identities. Without it, your sent mail is likely to be flagged as spam. If you intend to use a custom mail server (see the following section), these instructions will not be relevant to you. Otherwise:
 
 1. Ensure that your server's name in DigitalOcean `matches your full domain name <https://www.digitalocean.com/community/questions/how-do-i-setup-a-ptr-record?comment=30810>`_, and that the `hostname does as well <https://askubuntu.com/questions/938786/how-to-permanently-change-host-name/938791#938791>`_. If you had to make changes for this step, restart the server to ensure they take effect.
-2. Now, you'll need to generate a cryptographic keypair and enable the DKIM configuration. Run these commands:
+2. There can be in some cases a placeholder folder that you may have to delete first. If you run this command and no file was deleted, proceed to step 3.
+
+   .. code-block:: console
+
+     rmdir ~/central/files/dkim/rsa.private
+
+3. Now, you'll need to generate a cryptographic keypair and enable the DKIM configuration. Run these commands:
 
    .. code-block:: console
 
@@ -194,12 +200,12 @@ DKIM is a security trust protocol which is used to help verify mail server ident
      openssl rsa -in rsa.private -out rsa.public -pubout -outform PEM
      cp config.disabled config
 
-3. With the contents of the public key (``cat rsa.public``), you'll want to create two new TXT DNS records:
+4. With the contents of the public key (``cat rsa.public``), you'll want to create two new TXT DNS records:
 
    1. At the location ``dkim._domainkey.YOUR-DOMAIN-NAME-HERE``, create a new ``TXT`` record with the contents ``k=rsa; p=PUBLIC-KEY-HERE``. You only want the messy text *between* the dashed boundaries, and you'll want to be sure to remove any line breaks in the public key text, so that it's all only letters, numbers, ``+``, and ``/``.
    2. At your domain name location, create a new ``TXT`` record with the contents ``v=spf1 a mx ip4:SERVER-IP-ADDRESS-HERE -all`` where you can obtain the server IP address from the DigitalOcean control panel.
 
-4. Finally, build and run to configure EXIM to use the cryptographic keys you generated:
+5. Finally, build and run to configure EXIM to use the cryptographic keys you generated:
 
    .. code-block:: console
 

--- a/src/central-submissions.rst
+++ b/src/central-submissions.rst
@@ -72,12 +72,18 @@ To find the Form submissions page, first find the form in the Form listings page
 
    .. image:: /img/central-submissions/listing.png
 
-The table preview you see here will show you the first ten fields of your survey and their results, with the latest submissions shown closest to the top. Any downloadable files will appear with a green download link you can use to directly download that media attachment. The submission's instance ID will always be shown at the right side of this preview table.
+The table preview you see here will at first show you the first ten fields of your survey and their results, with the latest submissions shown closest to the top. Any downloadable files will appear with a green download link you can use to directly download that media attachment. The submission's instance ID will always be shown at the right side of this preview table.
+
+You can show more columns by accessing the !!TODO!! :guilabel:`Shown Columns` dropdown and checking the columns you wish to see. While the Shown Columns pane is open, you can use your browser's search feature (usually Ctrl+F or Cmd+F) to search for particular column name if you have many.
+
+You can limit the rows that appear by the submission author and the date. These filter controls are available just above the submission table.
 
 It is not yet possible to screen or delete submissions for quality or edit submission data. These features are planned for future releases. For now, you will need to pull your data out of Central before you can work with it. Right now, you can do this in one of two ways:
 
 1. The **CSV Download** option will get you a :file:`.zip` file containing one or more :file:`.csv` tables, along with any multimedia submitted to the form. This is a good option if you already have custom tools you wish to use, or you want to import it into an offline analysis tool like SPSS or Stata.
 2. The **OData connector** allows you connect a live representation of the data to OData-capable tools like Microsoft Excel, Microsoft Power BI, Tableau, SAP, and others. This option has some advantages: the data is transferred more richly to maintain more data format information, and the feed is always live, meaning any analysis or reports you perform in your tool over an OData connection can be easily refreshed as more submissions come in.
+
+When the table has row filters applied to it (ie it has been filtered by submission author or date), that filter also applies to the downloads. This makes it possible to download partial sections of your data at once.
 
 Learn more about these options below:
 

--- a/src/central-troubleshooting.rst
+++ b/src/central-troubleshooting.rst
@@ -3,6 +3,34 @@
 Troubleshooting Central 
 =========================
 
+.. _troubleshooting-data:
+
+Database disappeared after running Docker commands
+--------------------------------------------------
+
+It is possible to accidentally reset the database by running `docker-compose down`. We are working on a way to prevent this error in the future. For now, if you have run this command and your data has disappeared, you can follow these steps to relocate the data and attach it back to your server:
+
+1. Run the following command: ``docker inspect --type container central_postgres_1 -f '{{(index .Mounts 0).Source}}'``. It should print out a long name starting with /var/lib/docker/volumes/ and ending in a long string of letters and numbers. Copy those letters and numbers and set them aside. They correspond to the location of your current (reset) database.
+2. Run ``docker volume ls``. This will tell you all the locations that docker has stored information. We need to find the location that contains your old data.
+3. For each long string of letters and numbers you just printed out, run ``file /var/lib/docker/volumes/{letters and numbers}/_data/pg_hba.conf``. So for example, ``file /var/lib/docker/volumes/cd597c21c7f0920fd46001dfd36d454178d61a01b94936f388b082d698c7b9bb/_data/pg_hba.conf``.
+4. If it tells you ``No such file or directory``, move onto the next row and try again with the ``file`` command.
+5. If it says ``ASCII text``, you have found database data. But if the string of letters and numbers you just pasted is the same as what you found in step 1, it's not the data you're looking for. Move onto the next set of letters and numbers and try again with step 3.
+6. Hopefully you found the data before you got to the end of the list. We found two sets of important letters and numbers following these steps: one in step 1 and one is step 5. Call these FIRST and SECOND, respectively.
+7. Now to restore the data, you'll want to run the following commands:
+
+  .. code-block:: console
+
+    cd
+    cd central
+    docker-compose stop
+    pushd /var/lib/docker/volumes
+    mv FIRST postgres.data.bak
+    mv SECOND FIRST
+    popd
+    docker-compose up -d
+
+Go to your site in a browser and try to log in with an account that previously existed. If that doesn't immediately work, try doing another ``docker-compose stop`` followed by ``docker-compose up``.
+
 .. _troubleshooting-emails:
 
 Users aren't receiving emails
@@ -19,3 +47,4 @@ Email sounds like a simple technology but in practice there are many things that
 To address delivery issues, consider using a dedicated email service such as `Mailgun <https://www.mailgun.com/smtp/>`_. Because Central doesn't send very many emails, using such a service will generally be a cost-effective way of ensuring email delivery. Once you have an account set up, you will need to :ref:`configure Central to use it <central-install-digital-ocean-custom-mail>`.
 
 If you want to directly send emails from your Central installation, the `mail-tester <https://www.mail-tester.com/>`_ service can help you identify what barriers to email delivery you might have. Create a Central account with the email address that it provides, retrieve your results, and then delete the user. Typically, the first thing you will need to do is :ref:`configure DKIM <central-install-digital-ocean-dkim>` which will provide email recipients confidence that emails were actually sent by your Central server rather than by a spammer pretending to be your server.
+


### PR DESCRIPTION
documents:

* v1.1 new submission filters (wip needs final name and screenshots)
* v1.1 new ad hoc backup feature
* `exit 0` status for `secrets` container on `docker-compose ps`
* deleting `rsa.private` folder when setting up dkim
* recovery instructions following `docker-compose down`