### PR TITLE
Update buttons and swipes functionality

### DIFF
--- a/src/collect-filling-forms.rst
+++ b/src/collect-filling-forms.rst
@@ -128,6 +128,9 @@ If you have a repeating group, you can remove existing instances of that repeat 
 Navigating the form 
 ------------------------
 
+.. note::
+  Since Collect v1.29, both swiping and button navigation are enabled by default on new installations. Prior to Collect v1.29 or for existing installations, only swiping was enabled by default.
+
 Swipe
 ~~~~~~~~~~
 
@@ -137,14 +140,10 @@ To move between questions, :gesture:`Swipe Left or Right`.
   :alt: A question screen in the Collect App. Overlaid on the screen is an icon of a hand with extended finger and arrows pointing left and right, representing a swiping gesture.
   :class: block
 
-.. video:: /vid/collect-completing-forms/swipe-example.mp4
-
-  Video showing swiping between three questions.
-
-Left and Right Buttons  
+Next and Back Buttons  
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you prefer Forward and Back buttons for navigation, you can switch to that in :menuselection:`⋮ -> General Settings -> User Interface`.
+If you prefer Next and Back buttons for navigation, you can change your navigation mode in :menuselection:`⋮ -> General Settings -> User Interface`.
 
 1. Open the *Action Menu* (:menuselection:`⋮`)
 

--- a/src/img/collect-completing-forms/question-screen-with-buttons.png
+++ b/src/img/collect-completing-forms/question-screen-with-buttons.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4d2ea7ea8beeb11c4f6597774cdc36fe0b373a7d5c62dc2951ce981554de4ea6
-size 90313
+oid sha256:5509495143f6c008873eee5fca297265b623f08bbdbf366416831f418729e37c
+size 63523

--- a/src/img/collect-forms/jumpscreen.png
+++ b/src/img/collect-forms/jumpscreen.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4b67d723340a5afb8b6b117d6a861c69a0fd0ded52b664277be1a8438ca0e006
-size 34449
+oid sha256:4183a62e4709a9c53a07362da41f52a9bc46e60972988079b94a69d17c9a4c7f
+size 72220

--- a/src/vid/collect-completing-forms/swipe-example.mp4
+++ b/src/vid/collect-completing-forms/swipe-example.mp4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9f125b2bedc89e062a732061bbe98e3e00ff54f7f92b45b9c497d244f7c26e40
-size 2048315


### PR DESCRIPTION
#### What is included in this PR?
* Clarifies that buttons and swipes is now the default navigation mode
* Refers to the next and back buttons as "next" and "back"
* Updates screenshots that include the next and back buttons
* Removes swiping video

The video didn't seem very useful to me so reclaiming the space felt worth it.

Images went through ImageOptim.