### PR TITLE
Wait for custom db, not bundled db

### DIFF
--- a/src/central-install-digital-ocean.rst
+++ b/src/central-install-digital-ocean.rst
@@ -321,6 +321,12 @@ Central ships with a PostgreSQL database server. To use your own custom database
       "database": "my-db-table"
     },
 
+4. Edit the file ``docker-compose.yml`` to update the command for the ``service`` container.
+
+  .. code-block:: console
+
+    command: [ "./wait-for-it.sh", "my-db-host:my-db-port", "--", "./start-odk.sh" ]
+
 5. Build and run: ``docker-compose build service``, ``docker-compose stop service``, ``docker-compose up -d service``.
 
 .. _central-install-digital-ocean-sentry:


### PR DESCRIPTION
Currently, Central checks the local DB before starting. If we have a custom DB, we should check that DB instead.

I'm not sure if this is the best approach to do that (e.g., maybe we can set the host:port as a variable somewhere), but I figure having something in the docs is better than nothing.

I did not verify this change actually works.

I considered adding language to remove all the Postgres container stuff from the docker-compose file, but the container itself is small, and big changes to docker-compose will likely result in merge conflicts for folks, and documenting both the how to remove things and the support burden of merge conflicts seems not worth it.