### PR TITLE
Corrected greater than less than condition example

### DIFF
--- a/src/form-logic.rst
+++ b/src/form-logic.rst
@@ -436,7 +436,7 @@ For example:
 :tc:`. >= 18`
   True if response is greater than or equal to 18.
 
-:tc:`. < 20 and . > 200`
+:tc:`. > 20 and . < 200`
   True if the response is between 20 and 200.
   
 :tc:`regex(.,'\p{L}+')`


### PR DESCRIPTION
closes #1296 



#### What is included in this PR?

Previously the example erroneously suggested that `. < 20 and . > 200` would evaluate to True  if the value was between 20 and 200. In actuality, this would evaluate universally to False. I switched around the direction of the greater/less than symbols.
