### PR TITLE
s3_website doesn't work on Ruby v3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
   deploy:
     working_directory: ~/work
     docker:
-      - image: circleci/ruby:latest
+      - image: circleci/ruby:2.7
     steps:
       - attach_workspace:
           at: ~/work


### PR DESCRIPTION
Builds with ruby v3 will fail on `s3_website install` with..

```
[info] Downloading https://github.com/laurilehmijoki/s3_website/releases/download/v3.4.0/s3_website.jar into /usr/local/bundle/gems/s3_website-3.4.0/s3_website-3.4.0.jar
/usr/local/bundle/gems/s3_website-3.4.0/bin/s3_website:253:in `initialize': No such file or directory @ rb_sysopen - https://github.com/laurilehmijoki/s3_website/releases/download/v3.4.0/s3_website.jar (Errno::ENOENT)
	from /usr/local/bundle/gems/s3_website-3.4.0/bin/s3_website:253:in `open'
	from /usr/local/bundle/gems/s3_website-3.4.0/bin/s3_website:253:in `block in download_jar'
	from /usr/local/bundle/gems/s3_website-3.4.0/bin/s3_website:252:in `open'
	from /usr/local/bundle/gems/s3_website-3.4.0/bin/s3_website:252:in `download_jar'
	from /usr/local/bundle/gems/s3_website-3.4.0/bin/s3_website:235:in `resolve_jar'
	from /usr/local/bundle/gems/s3_website-3.4.0/bin/s3_website:135:in `install'
	from /usr/local/bundle/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'
	from /usr/local/bundle/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'
	from /usr/local/bundle/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'
	from /usr/local/bundle/gems/thor-0.20.3/lib/thor/base.rb:466:in `start'
	from /usr/local/bundle/gems/s3_website-3.4.0/bin/s3_website:285:in `<top (required)>'
	from /usr/local/bundle/bin/s3_website:23:in `load'
	from /usr/local/bundle/bin/s3_website:23:in `<main>'
```