### PR TITLE
Add troubleshooting section about corrupt exports

### DIFF
--- a/src/central-install-digital-ocean.rst
+++ b/src/central-install-digital-ocean.rst
@@ -44,7 +44,7 @@ As you continue down this page, there are a few options that may be important to
  - If you are technically savvy and understand what an SSH key is, there is a field here that you will want to fill in. If not, don't worry about it.
 
 .. tip::
-  If you choose a 1GB machine and you have problems with exporting attachments, you may wish to :ref:`add a swapfile <central-install-digital-ocean-swap>`.
+  If you choose a 1GB machine and you have problems with exporting attachments, read :ref:`this troubleshooting tip <export-fails-and-produces-corrupt-zip>`.
 
 Once you click on **Create**, you'll be taken back to the Droplet management page. It may think for a moment, and then your new server should appear. Next to it will be an IP address, which should look something like ``183.47.101.24``. This is where your server is publicly located on the Internet. Don't worry, nobody can do anything with it until you let them.
 
@@ -221,11 +221,11 @@ DKIM is a security trust protocol which is used to help verify mail server ident
 Adding Swap
 -----------
 
-If you have installed Central on a 1GB droplet, you may encounter problems exporting submission .zip files when there are many attachments. Usually, the .zip file will end up being empty, or much smaller than expected and possibly corrupt.
+To avoid Central crashing if your server runs out of memory, you may want to add swap. If you are having issues with Central running out of memory, we recommend adding more physical memory. However, adding swap can be an effective temporary workaround or a preventative measure against spikes if, for example, multiple people initiate data exports at the same time.
 
-In this case, the first thing you can try is to add a swap file. We **do not** recommend adding swap unless you are struggling with attachment exports, and if you can afford it, upgrading to a 2GB machine will yield much better results than adding swap. But if you just need your export to work for now, this can be an effective workaround.
+Whether or not you choose to add swap, we recommend :ref:`monitoring memory usage <central-install-digital-ocean-monitoring>` and `adding memory <https://www.digitalocean.com/docs/droplets/how-to/resize/>`_ if your server is routinely running close to the physical memory limit.
 
-Log into your server so you have a console prompt, and run these commands, adapted from `this article <https://help.ubuntu.com/community/SwapFaq#How_do_I_add_a_swap_file.3F>`_:
+To add swap, log into your server so you have a console prompt, and run these commands, adapted from `this article <https://help.ubuntu.com/community/SwapFaq#How_do_I_add_a_swap_file.3F>`_:
 
 .. code-block:: console
 

--- a/src/central-install-digital-ocean.rst
+++ b/src/central-install-digital-ocean.rst
@@ -44,7 +44,7 @@ As you continue down this page, there are a few options that may be important to
  - If you are technically savvy and understand what an SSH key is, there is a field here that you will want to fill in. If not, don't worry about it.
 
 .. tip::
-  If you choose a 1GB machine and you have problems with exporting attachments, read :ref:`this troubleshooting tip <export-fails-and-produces-corrupt-zip>`.
+  If you choose a 1GB server and you have problems with exporting attachments, read :ref:`this troubleshooting tip <export-produces-corrupt-zip>`.
 
 Once you click on **Create**, you'll be taken back to the Droplet management page. It may think for a moment, and then your new server should appear. Next to it will be an IP address, which should look something like ``183.47.101.24``. This is where your server is publicly located on the Internet. Don't worry, nobody can do anything with it until you let them.
 

--- a/src/central-troubleshooting.rst
+++ b/src/central-troubleshooting.rst
@@ -50,23 +50,23 @@ Now, run ``nano /etc/docker/daemon.json`` to make those nameservers and, optiona
 
 Finally, stop the containers, restart Docker, and bring the containers back up with ``docker-compose stop``, ``systemctl restart docker`` and ``docker-compose up -d``.
 
-.. _export-fails-and-produces-corrupt-zip:
+.. _export-produces-corrupt-zip:
 
-Export fails and produces corrupt zip
--------------------------------------
+Export produces corrupt zip
+-----------------------------
 
-If you have installed Central on a 1GB droplet or your forms collect many large media attachments, you may encounter problems exporting submission .zip files. Usually, the .zip file will end up being empty, or much smaller than expected and possibly corrupt. If you are expecting to collect media files, we recommend having at least 2GB of memory. When collecting images, we recommend :ref:`specifying a maximum size in form design <scaling-down-images>`.
+If you have installed Central on a 1GB server or your forms collect many large media files, you may encounter problems exporting submission .zip files. Usually, the .zip file will end up being empty, or much smaller than expected and possibly corrupt. If you are expecting to collect media files, we recommend having at least 2GB of memory. When collecting images, we recommend :ref:`specifying a maximum size in form design <scaling-down-images>`.
 
-The preferred approach to addressing this is to increase the amount of memory that your server has. Instructions for doing this on Digital Ocean can be found `in this support article <https://www.digitalocean.com/docs/droplets/how-to/resize/>`_.
+The preferred approach to addressing this is to increase the amount of memory that your server has. Instructions for doing this on DigitalOcean can be found `in this support article <https://www.digitalocean.com/docs/droplets/how-to/resize/>`_.
 
-If you can't increase the memory available, you can alternately :ref:`add swap <central-install-digital-ocean-swap>`. This will be slower than adding real memory but can be acceptable if it is only needed for occasional exports.
+If you can't increase the memory available, you can alternately :ref:`add swap <central-install-digital-ocean-swap>`. This will result in slower performance than adding physical memory but can be acceptable if it is only needed for occasional exports.
 
 .. _file-upload-fails-with-413:
 
 File upload fails with 413
 ---------------------------
 
-If you get an error `413` when trying to upload a submission from a client such as ODK Collect or when trying to upload a form attachment, the file you are trying to upload is too large. By default, files up to 100MB are accepted. We typically recommend reducing the size of the files to upload if possible. For example, :ref:`images can be scaled down in form design <scaling-down-images>`.
+If you get an error `413` when trying to upload a submission or when trying to upload a form attachment, the file you are trying to upload is too large. By default, files up to 100MB are accepted. We typically recommend reducing the size of the files to upload if possible. For example, :ref:`images can be scaled down in form design <scaling-down-images>`.
 
 If you absolutely must upload files over 100MB, you can change the `client_max_body_size` `nginx` directive:
 

--- a/src/central-troubleshooting.rst
+++ b/src/central-troubleshooting.rst
@@ -50,6 +50,17 @@ Now, run ``nano /etc/docker/daemon.json`` to make those nameservers and, optiona
 
 Finally, stop the containers, restart Docker, and bring the containers back up with ``docker-compose stop``, ``systemctl restart docker`` and ``docker-compose up -d``.
 
+.. _export-fails-and-produces-corrupt-zip:
+
+Export fails and produces corrupt zip
+-------------------------------------
+
+If you have installed Central on a 1GB droplet or your forms collect many large media attachments, you may encounter problems exporting submission .zip files. Usually, the .zip file will end up being empty, or much smaller than expected and possibly corrupt. If you are expecting to collect media files, we recommend having at least 2GB of memory. When collecting images, we recommend :ref:`specifying a maximum size in form design <scaling-down-images>`.
+
+The preferred approach to addressing this is to increase the amount of memory that your server has. Instructions for doing this on Digital Ocean can be found `in this support article <https://www.digitalocean.com/docs/droplets/how-to/resize/>`_.
+
+If you can't increase the memory available, you can alternately :ref:`add swap <central-install-digital-ocean-swap>`. This will be slower than adding real memory but can be acceptable if it is only needed for occasional exports.
+
 .. _troubleshooting-docker-compose-down:
 
 Database disappeared after running Docker commands

--- a/src/central-troubleshooting.rst
+++ b/src/central-troubleshooting.rst
@@ -61,6 +61,24 @@ The preferred approach to addressing this is to increase the amount of memory th
 
 If you can't increase the memory available, you can alternately :ref:`add swap <central-install-digital-ocean-swap>`. This will be slower than adding real memory but can be acceptable if it is only needed for occasional exports.
 
+.. _file-upload-fails-with-413:
+
+File upload fails with 413
+---------------------------
+
+If you get an error `413` when trying to upload a submission from a client such as ODK Collect or when trying to upload a form attachment, the file you are trying to upload is too large. By default, files up to 100MB are accepted. We typically recommend reducing the size of the files to upload if possible. For example, :ref:`images can be scaled down in form design <scaling-down-images>`.
+
+If you absolutely must upload files over 100MB, you can change the `client_max_body_size` `nginx` directive:
+
+  .. code-block:: console
+
+    cd
+    cd central
+    docker-compose stop
+    nano files/nginx/odk.conf.template
+    <modify the nginx conf value for client_max_body_size>
+    docker-compose up -d
+
 .. _troubleshooting-docker-compose-down:
 
 Database disappeared after running Docker commands

--- a/src/form-question-types.rst
+++ b/src/form-question-types.rst
@@ -1637,6 +1637,8 @@ Provides the user a drawing pad and collects the drawn image.
 
   image,draw_image_widget,Draw widget ,draw,image type with draw appearance
 
+.. _scaling-down-images:
+
 Scaling down images
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/form-question-types.rst
+++ b/src/form-question-types.rst
@@ -1481,6 +1481,9 @@ For more details, see the `OpenMapKit`_ documentation.
 Image widgets
 ---------------
 
+.. tip::
+  Image files can be very large. We recommend always including :ref:`a maximum image size in form design <scaling-down-images>`. Also consider making test submissions to your server with the Internet conditions you expect when gathering data to make sure that you can send files of the size you expect.
+
 .. contents::
  :local:
 
@@ -1680,7 +1683,7 @@ Records audio using the device's microphone or a connected external microphone. 
 
 .. tip::
 
-  Audio files can quickly become very big so if you record audio in your form, make sure that you carefully consider your audio quality settings. Also test making submissions to your server with the Internet conditions you expect when gathering data to make sure that you can send files of the size you expect.
+  Audio files can quickly become very big so if you record audio in your form, make sure that you carefully consider your audio quality settings. Also test making test submissions to your server with the Internet conditions you expect when gathering data to make sure that you can send files of the size you expect.
 
   Android devices can make many sounds during use and these will be included in recordings. We recommend turning off sounds from button presses, camera shutters and notifications before recording.
 
@@ -1813,6 +1816,9 @@ will be compatible.
 
 Video widgets
 ----------------
+
+.. tip::
+  Video files can quickly get very large. We recommend explicitly configuring video options for every device you intend to use for data collection. Also make submissions to your server with the Internet conditions you expect when gathering data to make sure that you can send files of the size you expect. Note that Central :ref:`has a 100MB file upload size limit by default <file-upload-fails-with-413>`.
 
 .. contents::
  :local:

--- a/src/form-question-types.rst
+++ b/src/form-question-types.rst
@@ -1482,7 +1482,7 @@ Image widgets
 ---------------
 
 .. tip::
-  Image files can be very large. We recommend always including :ref:`a maximum image size in form design <scaling-down-images>`. Also consider making test submissions to your server with the Internet conditions you expect when gathering data to make sure that you can send files of the size you expect.
+  Image files can be very large. We recommend always including :ref:`a maximum image size in form design <scaling-down-images>`. Also, consider making test submissions to your server with the Internet conditions you expect when gathering data to make sure that you can send files of the size you expect.
 
 .. contents::
  :local:
@@ -1683,7 +1683,7 @@ Records audio using the device's microphone or a connected external microphone. 
 
 .. tip::
 
-  Audio files can quickly become very big so if you record audio in your form, make sure that you carefully consider your audio quality settings. Also test making test submissions to your server with the Internet conditions you expect when gathering data to make sure that you can send files of the size you expect.
+  Audio files can be very large so if you record audio in your form, make sure that you consider your audio quality settings. Also, consider making test submissions to your server with the Internet conditions you expect when gathering data to make sure that you can send files of the size you expect.
 
   Android devices can make many sounds during use and these will be included in recordings. We recommend turning off sounds from button presses, camera shutters and notifications before recording.
 
@@ -1818,7 +1818,7 @@ Video widgets
 ----------------
 
 .. tip::
-  Video files can quickly get very large. We recommend explicitly configuring video options for every device you intend to use for data collection. Also make submissions to your server with the Internet conditions you expect when gathering data to make sure that you can send files of the size you expect. Note that Central :ref:`has a 100MB file upload size limit by default <file-upload-fails-with-413>`.
+  Video files can be very large. We recommend configuring video options for every device you intend to use for data collection. Also make submissions to your server with the Internet conditions you expect when gathering data to make sure that you can send files of the size you expect. Note that Central :ref:`has a 100MB file upload size limit by default <file-upload-fails-with-413>`.
 
 .. contents::
  :local:


### PR DESCRIPTION
Closes #1295 
Closes #1294

#### What is included in this PR?
Central troubleshooting section about corrupt exports, Central troubleshooting section about max upload size, tip about video file size.

I decided to change our swap recommendations. Since memory usage can be unpredictable, it's a nice protection to have, and we do this for every server we set up. With a low swapiness, the performance impact should be minimal. Paired with monitoring, it gives server admins an opportunity to make adjustments to available memory without having to experience crashes.

I built and looked at the results locally.