### PR TITLE
Add background audio documentation

### DIFF
--- a/src/form-question-types.rst
+++ b/src/form-question-types.rst
@@ -2247,6 +2247,70 @@ Collects a signature from the user.
 
   image,signature_widget,Signature widget,signature,image type with signature appearance
 
+
+.. _field-list:
+
+Grouping multiple widgets on the same screen
+------------------------------------------------
+
+type
+  :tc:`begin_group`
+appearance
+  :tc:`field-list`
+
+The :tc:`field-list` appearance attribute, applied to a group of widgets, displays them all on a single screen.
+
+.. warning::
+
+  Relevance, constraint and calculation evaluation within the same screen is supported in Collect v1.22 and later.
+
+.. warning::
+
+  Displaying :ref:`repeats` on the same screen (inside a :tc:`field-list` group) is not supported.
+
+.. seealso::
+
+  :ref:`groups` and :ref:`repeats`.
+
+.. _select-grid:
+
+Grid of selects on the same screen
+------------------------------------
+
+If you have multiple select questions with the same choices, it can be helpful to group them on one screen.
+
+.. image:: /img/form-widgets/select-grid.*
+  :alt: A field-list group of questions, as displayed in the ODK Collect app on an Android phone. A grid of questions representing underlying conditions are displayed. For eacn condition, there are radio buttons to indicate 'Yes' or 'No'.
+
+
+To do this, put your select questions in a :tc:`field-list` group and use the following :th:`appearance` attributes:
+
+:tc:`label`
+  Only the option labels are displayed, without checkboxes. This is used for the top row with the 'Yes' and 'No' options in the example above.
+:tc:`list-nolabel`
+  Only checkboxes or radio buttons are displayed, without their labels. This is used for the question rows in the example above.
+:tc:`list`
+  The labels are displayed along with checkboxes for multi-select questions and radio buttons for single-select questions. You could use this instead of having a :tc:`label` row to keep the option labels closer to the checkboxes or radio buttons.
+
+.. rubric:: XLSForm
+
+.. csv-table:: survey
+  :header: type, name, label, appearance
+
+  begin_group, underlying_conditions, Underlying conditions, field-list
+  select_one, yes_no, condition_labels, Conditions, label
+  select_one, yes_no, Comcond_preg, Pregnancy, list-nolabel
+  select_one, yes_no, Comcond_partum, Post-partum (< 6 weeks), list-nolabel
+  end_group, underlying_conditions
+
+.. csv-table:: choices
+  :header: list_name, name, label
+
+  yes_no, yes, Yes
+  yes_no, no, No
+
+  --------
+
 .. _hidden-questions:
 
 Hidden questions
@@ -2336,64 +2400,3 @@ storing the values for later use.
 For more details, see :ref:`calculations`.
 
 --------
-
-.. _field-list:
-
-Grouping multiple widgets on the same screen
-------------------------------------------------
-
-type
-  :tc:`begin_group`
-appearance
-  :tc:`field-list`
-
-The :tc:`field-list` appearance attribute, applied to a group of widgets, displays them all on a single screen.
-
-.. warning::
-
-  Relevance, constraint and calculation evaluation within the same screen is supported in Collect v1.22 and later.
-
-.. warning::
-
-  Displaying :ref:`repeats` on the same screen (inside a :tc:`field-list` group) is not supported.
-
-.. seealso::
-
-  :ref:`groups` and :ref:`repeats`.
-
-.. _select-grid:
-
-Grid of selects on the same screen
-------------------------------------
-
-If you have multiple select questions with the same choices, it can be helpful to group them on one screen.
-
-.. image:: /img/form-widgets/select-grid.*
-  :alt: A field-list group of questions, as displayed in the ODK Collect app on an Android phone. A grid of questions representing underlying conditions are displayed. For eacn condition, there are radio buttons to indicate 'Yes' or 'No'.
-
-
-To do this, put your select questions in a :tc:`field-list` group and use the following :th:`appearance` attributes:
-
-:tc:`label`
-  Only the option labels are displayed, without checkboxes. This is used for the top row with the 'Yes' and 'No' options in the example above.
-:tc:`list-nolabel`
-  Only checkboxes or radio buttons are displayed, without their labels. This is used for the question rows in the example above.
-:tc:`list`
-  The labels are displayed along with checkboxes for multi-select questions and radio buttons for single-select questions. You could use this instead of having a :tc:`label` row to keep the option labels closer to the checkboxes or radio buttons.
-
-.. rubric:: XLSForm
-
-.. csv-table:: survey
-  :header: type, name, label, appearance
-
-  begin_group, underlying_conditions, Underlying conditions, field-list
-  select_one, yes_no, condition_labels, Conditions, label
-  select_one, yes_no, Comcond_preg, Pregnancy, list-nolabel
-  select_one, yes_no, Comcond_partum, Post-partum (< 6 weeks), list-nolabel
-  end_group, underlying_conditions
-
-.. csv-table:: choices
-  :header: list_name, name, label
-
-  yes_no, yes, Yes
-  yes_no, no, No

--- a/src/form-question-types.rst
+++ b/src/form-question-types.rst
@@ -2,6 +2,7 @@
 
   abcd
   ack
+  bitrate
   br
   BREATHCOUNT
   Codabar
@@ -2309,7 +2310,7 @@ To do this, put your select questions in a :tc:`field-list` group and use the fo
   yes_no, yes, Yes
   yes_no, no, No
 
-  --------
+--------
 
 .. _hidden-questions:
 
@@ -2399,4 +2400,44 @@ storing the values for later use.
 
 For more details, see :ref:`calculations`.
 
---------
+.. _background-audio:
+
+Background audio
+~~~~~~~~~~~~~~~~~
+
+type
+  :tc:`background-audio`
+
+.. versionadded:: 1.30
+
+  `ODK Collect v1.30.0 <https://github.com/getodk/collect/releases/tag/v1.30.0>`_, `pyxform` v1.4.0, `XLSForm Online` v2.4.0
+
+.. seealso::
+  :doc:`Logging enumerator behavior <form-audit-log>`, :ref:`audio questions <audio>`
+
+.. rubric:: XLSForm
+
+.. csv-table:: survey
+  :header: type, name
+
+  background-audio, my_recording
+
+When a form includes a question of type :tc:`backgroud-audio`, audio is recorded while the form is open and attached to the form submission as a single audio file. These recordings can be used for quality assurance, training, transcription, and more. Use background recording instead of an :ref:`audio question <customizing-audio-quality>` when you want to make sure to record everything that happens during form filling.
+
+Before adding background audio recording to your form, make sure that you have a plan for following local laws around audio recording. We generally recommend including a note at the beginning of the form to remind data collectors and participants that they are being recorded and to describe the purpose of the recording. Depending on the context, you may be required to ask for the consent of every person in speaking range of the microphone. <Examples>
+
+Additionally, you should make a plan for using the resulting audio files. Do you have someone who can listen to and make sense of many audio files? Could you get access to speech-to-text capabilities? Also consider whether your data collectors will be able to send audio files. Will they have access to a fast enough Internet connection? Will their Internet plan or number of credits allow them to send all the audio files you expect?
+
+The default audio settings minimize file size while maintaining reasonable quality for a conversation between two people. Audio files will be saved in the `amr` format with a bitrate of 12.2kbps and a sample rate of 8kHz, resulting in a file size of about 5MB per hour. This corresponds to the ``voice-only`` quality :ref:`for audio questions <customizing-audio-quality>`. You can override that default quality by specifying a value in the :th:`parameters` column in the same way as :ref:`for audio questions <customizing-audio-quality>`.
+
+While recording is ongoing, an audio status bar is shown at the top of the screen. This bar helps remind data collectors that they are being recorded and provides visual feedback about audio volume. If a data collector exits a form and then re-opens it for editing, audio recording is resumed. Audio recording continues as long as the form is open, even if another application is in the foreground or the screen is locked. Note that settings can't be accessed directly from a form that has background recording. The audio file sent to the server will include audio from every time that the form was opened for editing.
+
+.. tip::
+
+  Android devices can make many sounds during use and these will be included in recordings. We recommend turning off sounds from button presses, camera shutters and notifications before recording.
+
+It can be helpful to combine background audio recording with :doc:`audit logging <form-audit-log>` to have more context while listening to the recording. Recording starts at the ``form start`` and ``form resume`` events and stops at the ``form exit`` event. You can use the difference between the ``form start`` time and the start time of an event to identify how far into the background recording a certain event happened.
+
+There is an override available to data collectors when recording might compromise safety or when consent to record can't be obtained but it's still important to capture some data. When the audio recording option is unchecked, audio recording ends immediately and any previously-recorded audio is deleted. Recording can't be resumed during the current form-filling session. The setting persists across form filling sessions. If :doc:`audit logging <form-audit-log>` is enabled, a ``background audio disabled`` event will be logged if a data collector toggles off recording and a ``background audio enabled`` event will be logged if a data collector toggles it back on.
+
+In some rare cases such as the device running out of space, the recording may complete successfully but not be attached to the form. If this happens, the recording may be available in the ``recordings`` folder of the :ref:`Collect directory <collect-directory>`. This folder is never cleared so consider emptying it yourself once you have retrieved its files.

--- a/src/form-question-types.rst
+++ b/src/form-question-types.rst
@@ -2400,10 +2400,10 @@ storing the values for later use.
 
 For more details, see :ref:`calculations`.
 
-.. _background-audio:
+.. _background-audio-recording:
 
-Background audio
-~~~~~~~~~~~~~~~~~
+Background audio recording
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 type
   :tc:`background-audio`
@@ -2424,20 +2424,38 @@ type
 
 When a form includes a question of type :tc:`backgroud-audio`, audio is recorded while the form is open and attached to the form submission as a single audio file. These recordings can be used for quality assurance, training, transcription, and more. Use background recording instead of an :ref:`audio question <customizing-audio-quality>` when you want to make sure to record everything that happens during form filling.
 
-Before adding background audio recording to your form, make sure that you have a plan for following local laws around audio recording. We generally recommend including a note at the beginning of the form to remind data collectors and participants that they are being recorded and to describe the purpose of the recording. Depending on the context, you may be required to ask for the consent of every person in speaking range of the microphone. <Examples>
+By default, audio files will be saved in the `amr` format with a bitrate of 12.2kbps and a sample rate of 8kHz, resulting in a file size of about 5MB per hour. These settings correspond to the ``voice-only`` quality :ref:`for audio questions <customizing-audio-quality>` and minimize file size while maintaining reasonable quality for a conversation between two people. You can override that default quality by specifying a value in the :th:`parameters` column as described :ref:`for audio questions <customizing-audio-quality>`.
+
+.. rubric:: XLSForm
+
+.. csv-table:: survey
+  :header: type, name, parameters
+
+  background-audio, my_recording, quality=low
+
+Planning for background audio recording
+"""""""""""""""""""""""""""""""""""""""""
+
+Before adding background audio recording to your form, make sure that you have a plan for following local laws around audio recording. We generally recommend including a note at the beginning of the form to remind data collectors and participants that they are being recorded and to describe the purpose of the recording. Depending on the context, you may be required to ask for the consent of every person in speaking range of the microphone.
 
 Additionally, you should make a plan for using the resulting audio files. Do you have someone who can listen to and make sense of many audio files? Could you get access to speech-to-text capabilities? Also consider whether your data collectors will be able to send audio files. Will they have access to a fast enough Internet connection? Will their Internet plan or number of credits allow them to send all the audio files you expect?
 
-The default audio settings minimize file size while maintaining reasonable quality for a conversation between two people. Audio files will be saved in the `amr` format with a bitrate of 12.2kbps and a sample rate of 8kHz, resulting in a file size of about 5MB per hour. This corresponds to the ``voice-only`` quality :ref:`for audio questions <customizing-audio-quality>`. You can override that default quality by specifying a value in the :th:`parameters` column in the same way as :ref:`for audio questions <customizing-audio-quality>`.
+It can be helpful to combine background audio recording with :doc:`audit logging <form-audit-log>` to have more context while listening to the recording. Recording starts at the ``form start`` and ``form resume`` events and stops at the ``form exit`` event. You can use the difference between the ``form start`` time and the start time of an event to identify how far into the background recording a certain event happened.
 
-While recording is ongoing, an audio status bar is shown at the top of the screen. This bar helps remind data collectors that they are being recorded and provides visual feedback about audio volume. If a data collector exits a form and then re-opens it for editing, audio recording is resumed. Audio recording continues as long as the form is open, even if another application is in the foreground or the screen is locked. Note that settings can't be accessed directly from a form that has background recording. The audio file sent to the server will include audio from every time that the form was opened for editing.
+Background audio recording user interface
+""""""""""""""""""""""""""""""""""""""""""
+
+While recording is ongoing, an audio status bar is shown at the top of the screen. This bar helps remind data collectors that they are being recorded and provides visual feedback about audio volume. 
+
+If a data collector exits a form and then re-opens it for editing, audio recording is resumed. Audio recording continues as long as the form is open, even if another application is in the foreground or the screen is locked. Note that Collect settings can't be accessed directly from a form that has background recording. The audio file sent to the server will include audio from every time that the form was opened for editing.
 
 .. tip::
 
   Android devices can make many sounds during use and these will be included in recordings. We recommend turning off sounds from button presses, camera shutters and notifications before recording.
 
-It can be helpful to combine background audio recording with :doc:`audit logging <form-audit-log>` to have more context while listening to the recording. Recording starts at the ``form start`` and ``form resume`` events and stops at the ``form exit`` event. You can use the difference between the ``form start`` time and the start time of an event to identify how far into the background recording a certain event happened.
+There is an override available to data collectors when recording might compromise safety or when consent to record can't be obtained but it's still important to capture some data. When the audio recording option is unchecked, audio recording ends immediately and any previously-recorded audio is deleted. Recording can't be resumed during the current form-filling session. Toggling the audio recording option back on indicates that the next form filling session should be recorded. If :doc:`audit logging <form-audit-log>` is enabled, a ``background audio disabled`` event will be logged if a data collector toggles off recording and a ``background audio enabled`` event will be logged if a data collector toggles it back on.
 
-There is an override available to data collectors when recording might compromise safety or when consent to record can't be obtained but it's still important to capture some data. When the audio recording option is unchecked, audio recording ends immediately and any previously-recorded audio is deleted. Recording can't be resumed during the current form-filling session. The setting persists across form filling sessions. If :doc:`audit logging <form-audit-log>` is enabled, a ``background audio disabled`` event will be logged if a data collector toggles off recording and a ``background audio enabled`` event will be logged if a data collector toggles it back on.
+Background audio recording troubleshooting
+""""""""""""""""""""""""""""""""""""""""""""
 
 In some rare cases such as the device running out of space, the recording may complete successfully but not be attached to the form. If this happens, the recording may be available in the ``recordings`` folder of the :ref:`Collect directory <collect-directory>`. This folder is never cleared so consider emptying it yourself once you have retrieved its files.


### PR DESCRIPTION
To be shipped with Collect v1.30

I recommend looking at the two commits separately. There's a little bit of redundancy with the foreground audio section but I couldn't find smooth ways to link between them. This feels ok and I think it's fine if the wording ends up deviating a little bit.

Any screenshot needed? I've gone back and forth on adding one of the top bar.

TODO:
- [x] Basic sample form
- [ ] Examples of introduction screens. I'd like to do one that's just informational, one that asks for consent and one that allows the respondent to pick topics they're comfortable discussing while being recorded. I'm hesitating between attaching XLSX files and putting the form defs inline but collapsed by default. I'd love thoughts on that or other options!