### PR TITLE
Ubuntu 16 is no longer the recommended LTS

### DIFF
--- a/src/central-install.rst
+++ b/src/central-install.rst
@@ -39,15 +39,15 @@ Installing on Amazon EC2
 
 Amazon Web Services (AWS) is one of the many other options for installing Central. It's a good idea to read through the :doc:`instructions we've provided <central-install-digital-ocean>` for DigitalOcean, as many of the steps remain the same or similar.
 
-To obtain a server you will need to first `create an AWS account <https://aws.amazon.com/>`_. When launching your instance, select the Ubuntu Server 16.04 LTS Amazon Machine Image (AMI) in step 1. The ``t2.micro`` instance type has the 1GB of memory recommended for if you don't expect many forms to be submitted at once and you don't expect many large media attachments.
+To obtain a server you will need to first `create an AWS account <https://aws.amazon.com/>`_. When launching your instance, select the Ubuntu Server 20.04 LTS AMI in step 1. The ``t2.micro`` instance type has the 1GB of memory recommended for if you don't expect many forms to be submitted at once and you don't expect many large media attachments.
 
 When adjusting the security settings open up the ports for SSH, HTTP, and HTTPS. Once you have launched your instance, go to the Elastic IPs menu option under Network & Security, then allocate a new address and associate it with your server in order to keep the IP address for your server consistent.
 
-Before installing Central on your server, you need to install Docker and Docker Compose.
+Before installing Central on your server, you need to install Docker and Docker Compose. Follow the instructions below.
 
-1. Docker. Steps 1 and 2 of this `how to install Docker on Ubuntu 16.04 tutorial <https://www.digitalocean.com/community/tutorials/how-to-install-and-use-docker-on-ubuntu-16-04>`_ should walk you through the necessary commands. In step 2 add the ``ubuntu`` user to the Docker group.
+1. `Install Docker Engine on Ubuntu <https://docs.docker.com/engine/install/ubuntu/>`_. 
 
-2. Docker Compose. This `how to install Docker Compose on Ubuntu 16.04 tutorial <https://www.digitalocean.com/community/tutorials/how-to-install-docker-compose-on-ubuntu-16-04>`_ should walk you through the necessary commands. You should only need to complete step 1. You can change the version number to ``1.24.1``.
+2. `Install Docker Compose <https://docs.docker.com/compose/install/>`_. 
 
 After installing Docker and Docker Compose you can follow our DigitalOcean instructions from running ``git clone https://github.com/getodk/central``. Continue with the DigitalOcean instructions for logging into Central.
 


### PR DESCRIPTION
I have personally use this AMI and the instructions, so I know they work!

<img width="747" alt="Screen Shot 2021-04-23 at 09 00 44" src="https://user-images.githubusercontent.com/32369/115898961-0af38f00-a413-11eb-8c51-2ae802440c09.png">
