### PR TITLE
Update Aggregate language, remove XLSForm Offline

### DIFF
--- a/src/aggregate-admin.rst
+++ b/src/aggregate-admin.rst
@@ -2,7 +2,7 @@ Administering Aggregate
 ===========================
 
 .. warning::
-  Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
+  ODK Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
 
 Click the :guilabel:`Log In` link in the upper right corner of the screen to be presented with the Log onto Aggregate screen. Choose the :guilabel:`Sign in with Aggregate password` button and enter the super-user username you specified within the installer. The initial password for this account is `aggregate`. When you log in, :guilabel:`Site Admin` will be visible to you.
 

--- a/src/aggregate-app-engine-legacy.rst
+++ b/src/aggregate-app-engine-legacy.rst
@@ -6,7 +6,7 @@ Google App Engine Support (Legacy)
 ==================================
 
 .. warning::
-  Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
+  ODK Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
 
 .. warning::
 

--- a/src/aggregate-app-engine.rst
+++ b/src/aggregate-app-engine.rst
@@ -4,7 +4,7 @@ Installing Aggregate on Google App Engine
 =========================================
 
 .. warning::
-  Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
+  ODK Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
 
 .. warning::
 

--- a/src/aggregate-aws.rst
+++ b/src/aggregate-aws.rst
@@ -8,7 +8,7 @@ Installing on Amazon Web Services
 =================================
 
 .. warning::
-  Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
+  ODK Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
 
 .. warning::
 

--- a/src/aggregate-azure.rst
+++ b/src/aggregate-azure.rst
@@ -7,7 +7,7 @@ Installing on Microsoft Azure
 =============================
 
 .. warning::
-  Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
+  ODK Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
 
 .. warning::
 

--- a/src/aggregate-backup.rst
+++ b/src/aggregate-backup.rst
@@ -6,7 +6,7 @@ Backing Up Aggregate
 ====================
 
 .. warning::
-  Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
+  ODK Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
 
 Backup and restore forms and submissions with Briefcase
 -------------------------------------------------------

--- a/src/aggregate-best-practices.rst
+++ b/src/aggregate-best-practices.rst
@@ -2,7 +2,7 @@ Tips and Best Practices
 ============================
 
 .. warning::
-  Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
+  ODK Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
 
 .. toctree::
   :maxdepth: 2

--- a/src/aggregate-boost-performance.rst
+++ b/src/aggregate-boost-performance.rst
@@ -4,7 +4,7 @@ Reducing Data Corruption and Boosting Performance
 =================================================
 
 .. warning::
-  Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
+  ODK Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
 
 .. warning::
 

--- a/src/aggregate-data-access.rst
+++ b/src/aggregate-data-access.rst
@@ -6,7 +6,7 @@ Getting Data Out of Aggregate
 ================================
 
 .. warning::
-  Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
+  ODK Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
 
 ODK Aggregate supports three primary mechanisms for data transfer:
 

--- a/src/aggregate-data.rst
+++ b/src/aggregate-data.rst
@@ -2,7 +2,7 @@ Working with Submitted Data in Aggregate
 =========================================
 
 .. warning::
-  Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
+  ODK Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
 
 You can view the data submitted from ODK Collect here. You can filter the submissions, visualize them using pie chart, bar graph or map, export the submissions into useful formats and publish the submitted data into another service. You can also view all the exported submissions. ODK Aggregate provides all these options under the :guilabel:`Submissions` tab.
 

--- a/src/aggregate-deployment-planning.rst
+++ b/src/aggregate-deployment-planning.rst
@@ -3,7 +3,7 @@ Planning Your Aggregate Deployment
 ***********************************
 
 .. warning::
-  Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
+  ODK Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
 
 ODK Aggregate can be deployed to :doc:`any local or cloud server that runs Tomcat, Java8, and PostgreSQL <aggregate-tomcat>` (MySQL is supported too).
 

--- a/src/aggregate-digital-ocean.rst
+++ b/src/aggregate-digital-ocean.rst
@@ -5,7 +5,7 @@ Installing on DigitalOcean (recommended)
 ========================================
 
 .. warning::
-  Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
+  ODK Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
 
 .. warning::
 

--- a/src/aggregate-field-length.rst
+++ b/src/aggregate-field-length.rst
@@ -6,7 +6,7 @@ Increasing Aggregate Field Length
 ====================================
 
 .. warning::
-  Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
+  ODK Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
 
 By default, Aggregate's datastore layer limits text values to 255 characters or less. If a submission includes a value longer than 255 characters, those additional characters **are not saved in the database** and no warning is shown. That means there is a risk of data loss when using question types that save long text values such as :ref:`geotrace <geotrace-widget>`, :ref:`geoshape <geoshape-widget>` or :ref:`select multiple <multi-select-widget>`. This limitation exists for performance reasons, particularly for older versions of MySQL.
 

--- a/src/aggregate-forms.rst
+++ b/src/aggregate-forms.rst
@@ -2,7 +2,7 @@ Managing Forms in Aggregate
 ================================
 
 .. warning::
-  Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
+  ODK Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
 
 You can add, download and delete forms, export data into useful formats, publish data into another service, manually upload submissions and view the published data. ODK Aggregate provides all these options under the :guilabel:`Form Management` tab.
 

--- a/src/aggregate-google-cloud.rst
+++ b/src/aggregate-google-cloud.rst
@@ -7,7 +7,7 @@ Installing on Google Cloud
 ==========================
 
 .. warning::
-  Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
+  ODK Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
 
 .. warning::
 

--- a/src/aggregate-help.rst
+++ b/src/aggregate-help.rst
@@ -2,7 +2,7 @@ Getting Help in Aggregate
 =============================
 
 .. warning::
-  Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
+  ODK Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
 
 Aggregate provides three kinds of help accessible by pressing one of three buttons in the upper righthand corner.
 

--- a/src/aggregate-install.rst
+++ b/src/aggregate-install.rst
@@ -3,7 +3,7 @@
 ======================
 
 .. warning::
-  Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
+  ODK Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
 
 .. toctree::
   :maxdepth: 1

--- a/src/aggregate-intro.rst
+++ b/src/aggregate-intro.rst
@@ -2,7 +2,7 @@ ODK Aggregate
 ===================
 
 .. warning::
-  Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
+  ODK Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
 
 .. _aggregate-introduction:
 

--- a/src/aggregate-limitations.rst
+++ b/src/aggregate-limitations.rst
@@ -2,7 +2,7 @@ Aggregate Limitations
 ========================
 
 .. warning::
-  Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
+  ODK Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
 
 This is a listing of known limitations and potential "gotchas" users of Aggregate may encounter.
 

--- a/src/aggregate-setup.rst
+++ b/src/aggregate-setup.rst
@@ -2,7 +2,7 @@ Setting Up ODK Aggregate
 ===============================
 
 .. warning::
-  Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
+  ODK Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
 
 .. toctree::
   :maxdepth: 2

--- a/src/aggregate-tomcat.rst
+++ b/src/aggregate-tomcat.rst
@@ -9,7 +9,7 @@ Installing on Tomcat
 ====================
 
 .. warning::
-  Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
+  ODK Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
 
 `Apache Tomcat <http://tomcat.apache.org/>`_ is an open source Java web server that can be used to serve ODK Aggregate.
 

--- a/src/aggregate-upgrade.rst
+++ b/src/aggregate-upgrade.rst
@@ -21,7 +21,7 @@ Upgrading Aggregate
 =====================
 
 .. warning::
-  Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
+  ODK Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
 
 .. _upgrade-aggregate:
 

--- a/src/aggregate-use.rst
+++ b/src/aggregate-use.rst
@@ -2,7 +2,7 @@ Using ODK Aggregate
 =====================
 
 .. warning::
-  Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
+  ODK Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
 
 .. toctree::
   :maxdepth: 2

--- a/src/aggregate-visualize.rst
+++ b/src/aggregate-visualize.rst
@@ -3,7 +3,7 @@ Visualizing Geographic Data
 ************************************
 
 .. warning::
-  Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
+  ODK Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
 
 This guide helps the users to visualize the collected geodata uploaded on ODK Aggregate server using `Google Earth <https://www.google.com/intl/en_in/earth/>`_.
 

--- a/src/aggregate-vm.rst
+++ b/src/aggregate-vm.rst
@@ -7,7 +7,7 @@ Installing the Virtual Machine
 ==============================
 
 .. warning::
-  Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
+  ODK Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
 
 This document provides instructions for installing :doc:`aggregate-intro` using the Virtual Machine (VM) and `VirtualBox <https://www.virtualbox.org>`_.
 

--- a/src/form-question-types.rst
+++ b/src/form-question-types.rst
@@ -1073,7 +1073,7 @@ Randomizing choice order
 
 .. note::
 
-  Randomizing choice order support was added in Collect v1.18.2 and Aggregate v1.7.1. Form conversion requires XLSForm Online ≥ v1.2.2, XLSForm Offline ≥ v1.7.1, or pyxform ≥ v0.11.6.
+  Randomizing choice order support was added in Collect v1.18.2 and Aggregate v1.7.1. Form conversion requires XLSForm Online ≥ v1.2.2 or pyxform ≥ v0.11.6.
 
 To reduce bias, choice order can be randomized for any of the select question types described above. To display the choices in a different order each time the question is displayed, set **randomize** to **true** in the :th:`parameters` column of the XLSForm **survey** sheet:
 
@@ -2480,7 +2480,7 @@ Geolocation at survey start
   :ref:`Audit log geolocation tracking <audit-geolocation-tracking>`
 
 .. note::
-  Geolocation at survey start was added in Collect v1.23 and Aggregate v2.0.4/v1.7.4. Form conversion requires XLSForm Online ≥ v1.6.1, XLSForm Offline ≥ v1.11.1 or pyxform ≥ v0.15.1.
+  Geolocation at survey start was added in Collect v1.23 and Aggregate v2.0.4/v1.7.4. Form conversion requires XLSForm Online ≥ v1.6.1 or pyxform ≥ v0.15.1.
 
 The :tc:`start-geopoint` question type is used to capture a single geolocation in :ref:`geopoint format <location-widgets>` when the survey is first started. Questions of type :tc:`start-geopoint` may be given any allowable name. Although it is possible to have more than one :tc:`start-geopoint` question in a form, all will have the same value.
 

--- a/src/form-update.rst
+++ b/src/form-update.rst
@@ -32,7 +32,7 @@ Updating forms in Aggregate
 ============================
 
 .. warning::
-  Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
+  ODK Aggregate is no longer being updated. Please use :doc:`ODK Central <central-intro>` instead.
 
 .. _change-existing:
 

--- a/src/security-privacy.rst
+++ b/src/security-privacy.rst
@@ -136,8 +136,6 @@ We require secure HTTPS connections to XLSForm Online. We gather aggregate user 
 
 XLSForm Online stores both your submitted XLS and the generated XML form for a period of time on its disk drive before being deleted. This is necessary for the operation of the tool.
 
-XLSForm Offline operates locally without any network communications and provides a secure alternative to the convenience of XLSForm Online.
-
 
 Cross-tool Concerns
 -------------------

--- a/src/xlsform.rst
+++ b/src/xlsform.rst
@@ -8,59 +8,12 @@ XLSForm
 
 .. _xlsform-introduction:
 
-:dfn:`XLSForm` is a form standard created to help simplify the authoring of forms in Excel. XLSForms are simple to get started with but allow for the authoring of complex forms. Forms designed with Excel can be converted to *XForms* that can be used with ODK tools.
+:dfn:`XLSForm` is a form standard created to help simplify the authoring of forms in Excel. XLSForms are simple to get started with but allow for the authoring of complex forms.
 
-To design your form, refer to the `XLSForm form design documentation <http://xlsform.org/>`_. Once the form has been designed, use `XLSForm Online <https://getodk.org/xlsform>`_, `XLSForm Offline <https://github.com/getodk/xlsform-offline/releases/latest>`_, or if you are comfortable on the command line, `pyxform <https://github.com/XLSForm/pyxform>`_.
-
-.. _online:
-
-XLSForm Online
---------------
-
-We recommend starting with XLSForm Online converter because it is always up-to-date and allows you to preview what the form will look like.
-
-Use `XLSForm Online <https://getodk.org/xlsform>`_.
-
-.. _offline:
-
-XLSForm Offline
----------------
-
-XLSForm Offline converter is a great option for users who do not have a reliable connection or may need to design forms offline.
-
-Download `XLSForm Offline <https://github.com/getodk/xlsform-offline/releases/latest>`_.
+To design your form, refer to the `XLSForm form design documentation <http://xlsform.org/>`_. Once the form has been designed, :ref:`upload the form to Central <central-forms-upload>`.
 
 .. tip::
 
-  There is a validation option in the XLSForm Offline that requires Java. To enable this option, download and install `Java <http://java.com/en/download>`_ and ensure Java is in your PATH. See `How do I set or change the PATH <http://java.com/en/download/help/path.xml>`_ for more.
+  If your ODK server does not support have the latest XLSForm features or you need to temporarily preview a form in a browser, try `XLSForm Online <https://getodk.org/xlsform>`_.
 
-.. note::
-
-  Your anti-virus may report that XLSForm Offline has a virus. This is a false positive that is triggered because virus writers sometimes use the same components we use. You can confirm the safety of XLSForm Offline by using the free and unbiased `VirusTotal <https://www.virustotal.com>`_. You may also use `XLSForm Online <https://getodk.org/xlsform>`_ as an alternative.
-
-  On macOS 10.7 or later, you may get a dialog on startup warning you that the XLSForm Offline is from an unidentified developer. Control-click or right click the icon of the app to bypass this dialog. See `About Gatekeeper <https://support.apple.com/en-us/HT202491>`_ for more.
-
-pyxform
---------
-
-`pyxform <https://github.com/XLSForm/pyxform>`_ is a Python library used as a library in `XLSForm Online <https://getodk.org/xlsform>`_ and `XLSForm Offline <https://github.com/getodk/xlsform-offline/releases/latest>`_.
-
-For those who want to convert forms at the command line, pyxform can be installed directly from the command line using `pip <https://en.wikipedia.org/wiki/Pip_(package_manager)>`_:
-
-.. code-block:: console
-  
-  $ pip install pyxform
-  
-The :command:`xls2xform` command can then be used:
-
-.. code-block:: console
-  
-  $ xls2xform path_to_XLSForm output_path
-  
-.. tip::
-
-  Use pyxform together with :doc:`adb <collect-adb>` to quickly convert an XLSForm and load it to :ref:`a device's Collect directory <collect-directory>`. Once you have both tools installed, convert and push in a single line:
-  
-  .. code-block:: console
-  
-    $ xls2xform form-name.xlsx form-name.xml && adb push form-name.xml <collect-directory>/forms/form-name.xml
+  If you need to design XLSForms offline or your form has sensitive data that you'd rather not upload into XLSForm Online, use the `pyxform <https://github.com/XLSForm/pyxform>`_ command line tool.


### PR DESCRIPTION
* Add "ODK" to Aggregate deprecation note to make for more balanced wording
* Remove description of XLSForm Offline
* Remove all references of XLSForm Offline versions because we don't want people using it
* Remove instructions for pyxform in favor of direct links
* Document the preferred way to design forms (upload them to Central)
* Explain when you'd want to use XLSForm Online and pyxform

<img width="733" alt="Screen Shot 2021-04-29 at 10 24 29" src="https://user-images.githubusercontent.com/32369/116592669-1ba17a80-a8d5-11eb-8fa3-aa3262b3c398.png">

The form design intro page is horrible still, but we'll save that for another day.