### PR TITLE
Update documentation for Central v1.2

### DIFF
--- a/src/central-install-digital-ocean.rst
+++ b/src/central-install-digital-ocean.rst
@@ -65,7 +65,7 @@ For the rest of us, there are some options here:
  - You can pay one of the many popular commercial domain registrars for a full domain name, like ``MyOdkCollectionServer.com``. Search for "domain registrar" to find one of these. These often cost as little as $3/year.
  - You can use a free DNS service: we recommend `FreeDNS <https://freedns.afraid.org/>`_, which has run for a long time and has a good reputation. With it, you can get a free name, albeit with a fixed second half (like ``MyOdkCollectionServer.dynet.com``). If you choose this route, we recommend using one of the *less popular* names, as the heavily occupied names can run into trouble later on (in particular, getting a security certificate from Let's Encrypt).
 
-Whichever option you choose, once you getting a domain name you'll want to look at `DigitalOcean's guide <https://www.digitalocean.com/docs/networking/dns>`_ on setting up domain names for your Droplet. In general, you'll point your domain name in DigitalOcean's direction at your registrar, then in DigitalOcean itself you'll want to create an A record that points to the IP address we found above.
+Whichever option you choose, once you get a domain name you'll want to look at `DigitalOcean's guide <https://www.digitalocean.com/docs/networking/dns>`_ on setting up domain names for your Droplet. In general, you'll point your domain name in DigitalOcean's direction at your registrar, then in DigitalOcean itself you'll want to create an A record that points to the IP address we found above.
 
 New domain names take a little bit to get working. Meanwhile, we can get working on installing the server software.
 
@@ -110,11 +110,13 @@ Now you'll need to download the software. In the server window, type ``git clone
 
 You now have the framework of the server software, but some components are missing. Type ``git submodule update -i`` and press **Enter** to download them.
 
-Next, you need to update some settings. Type ``nano .env`` and press **Enter**. This will launch a text editing application.
+Next, you need to update some settings. First, copy the settings template file so you can edit it: type ``mv .env.template .env`` and press **Enter**.
 
- - Change the ``SSL_TYPE`` line to read: ``SSL_TYPE=letsencrypt``. This instructs the server to attempt to obtain a security certificate from the free Let's Encrypt provider.
+Then, edit the file by typing ``nano .env`` and pressing **Enter**. This will launch a text editing application. 
+
  - Change the ``DOMAIN`` line so that after the ``=`` is the domain name you registered above. As an example: ``DOMAIN=MyOdkCollectionServer.com``. Do not include anything like ``http://``.
  - Change the ``SYSADMIN_EMAIL`` line so that after the ``=`` is your own email address. The Let's Encrypt service will use this address only to notify you if something is wrong with your security certificate.
+ - Leave the rest of the settings alone. If you have a custom security or network environment you are trying to integrate Central into, see the advanced configuration sections for more information on these options.
  - Hold ``Ctrl`` and press ``x`` to quit the text editor. Press ``y`` to indicate that you want to save the file, and then press **Enter** to confirm the file name. Do not change the file name.
 
    .. image:: /img/central-install/nano.png

--- a/src/central-install-digital-ocean.rst
+++ b/src/central-install-digital-ocean.rst
@@ -116,7 +116,7 @@ Then, edit the file by typing ``nano .env`` and pressing **Enter**. This will la
 
  - Change the ``DOMAIN`` line so that after the ``=`` is the domain name you registered above. As an example: ``DOMAIN=MyOdkCollectionServer.com``. Do not include anything like ``http://``.
  - Change the ``SYSADMIN_EMAIL`` line so that after the ``=`` is your own email address. The Let's Encrypt service will use this address only to notify you if something is wrong with your security certificate.
- - Leave the rest of the settings alone. If you have a custom security or network environment you are trying to integrate Central into, see the advanced configuration sections for more information on these options.
+ - Leave the rest of the settings alone. If you have a custom security or network environment you are trying to integrate Central into, see the :ref:`advanced configuration <central-install-digital-ocean-advanced>` sections for more information on these options.
  - Hold ``Ctrl`` and press ``x`` to quit the text editor. Press ``y`` to indicate that you want to save the file, and then press **Enter** to confirm the file name. Do not change the file name.
 
    .. image:: /img/central-install/nano.png

--- a/src/central-intro.rst
+++ b/src/central-intro.rst
@@ -17,27 +17,29 @@ Here are some of the major features we support today:
  - User accounts and management
  - Role-based user permissioning
  - Projects to organize users, permissions, and forms
- - Form and submission upload and management
+ - Form upload and management
 
    - With support for form version updates
    - With drafts and testing on initial creation, and on version updates
-   - With form and submission multimedia or data attachments
-   - With a table preview of submission data
+   - With form multimedia or data attachments
    - Encrypted forms (self-supplied or project managed keys)
-   - OData live data feed for analysis with tools like Excel and Power BI
 
- - Form filling directly in the web browser using `Enketo <https://enketo.org>`_
+ - Submission upload and management
+
+   - From any compliant data collection client,
+   - Or directly from a web browser using `Enketo <https://enketo.org>`_ technology
+   - From permissions-managed known users or anonymous public links
+   - With submission multimedia or data attachments
+   - With an interactive table preview of submission data
+   - OData live data feed for analysis with tools like Excel and Power BI
+   - Support for reviewing, commenting on, and editing submissions after upload
+
  - Integrated checklist-based help system
  - Optional encrypted off-site data backups to Google Drive
  - Clean and modern REST API for integration and extensibility
  - High performance on low-cost hardware or cloud providers
  - ODK Briefcase-compatible data output
  - ODK Briefcase push/pull support
-
-Here are some (but not all) key features we **do not yet** support:
-
- - Customizable user roles
- - Submission edits
 
 Central is in active development. We have a lot of exciting ideas for its future and we look forward to hearing yours as well. See `What is coming in Central <https://forum.getodk.org/t/whats-coming-in-central-over-the-next-few-years/19677>`_ for more on future direction.
 

--- a/src/central-intro.rst
+++ b/src/central-intro.rst
@@ -14,10 +14,9 @@ ODK Central Features
 
 Here are some of the major features we support today:
 
- - User accounts and management
- - Role-based user permissioning
  - Projects to organize users, permissions, and forms
  - Form upload and management
+ - User accounts with role-based permissioning
 
    - With support for form version updates
    - With drafts and testing on initial creation, and on version updates
@@ -26,13 +25,12 @@ Here are some of the major features we support today:
 
  - Submission upload and management
 
-   - From any compliant data collection client,
-   - Or directly from a web browser using `Enketo <https://enketo.org>`_ technology
+   - From filling from our mobile app or a web browser
    - From permissions-managed known users or anonymous public links
    - With submission multimedia or data attachments
    - With an interactive table preview of submission data
-   - OData live data feed for analysis with tools like Excel and Power BI
    - Support for reviewing, commenting on, and editing submissions after upload
+   - Connectable to data analysis and dashboard applications like Excel, Power BI, or R over OData
 
  - Integrated checklist-based help system
  - Optional encrypted off-site data backups to Google Drive

--- a/src/central-server-audits.rst
+++ b/src/central-server-audits.rst
@@ -14,7 +14,7 @@ As of `version 0.6 <https://github.com/getodk/central/releases/tag/v0.6.0-beta.0
  - **Form Actions**
 
    - Create
-   - Update Details (state, drafts, publishes, settings)
+   - Update Details (state, draft upload, publish action, settings)
    - Update Attachments
    - Delete
 

--- a/src/central-server-audits.rst
+++ b/src/central-server-audits.rst
@@ -5,6 +5,26 @@ Server Audit Logs in Central
 
 As of `version 0.6 <https://github.com/getodk/central/releases/tag/v0.6.0-beta.0>`_, ODK Central tracks and logs audit actions for most administrative actions performed on the server. The following actions are logged:
 
+ - **Project Actions**
+
+   - Create
+   - Update Details (name, settings, archival)
+   - Delete
+
+ - **Form Actions**
+
+   - Create
+   - Update Details (state, drafts, publishes, settings)
+   - Update Attachments
+   - Delete
+
+ - **Submission Actions**
+
+   - Create
+   - Update Metadata (review state)
+   - Update Submission Data
+   - Update Attachments
+
  - **Web User Actions**
 
    - Create
@@ -13,16 +33,20 @@ As of `version 0.6 <https://github.com/getodk/central/releases/tag/v0.6.0-beta.0
    - Revoke Role
    - Retire
 
- - **Project Actions**
+ - **App User Actions**
 
    - Create
-   - Update Details (name, settings, archival)
+   - Assign Role
+   - Revoke Role
+   - Revoke Access
+   - Delete
 
- - **Form Actions**
+ - **Public Link Actions**
 
    - Create
-   - Update Details (state, settings)
-   - Update Attachments
+   - Assign Role
+   - Revoke Role
+   - Revoke Access
    - Delete
 
 To access the audit logs, navigate to :guilabel:`System`, then select :guilabel:`Server Audit Logs` from the navigation menu that appears:

--- a/src/central-submissions.rst
+++ b/src/central-submissions.rst
@@ -2,6 +2,7 @@
 
   Ctrl
   Cmd
+  concat
 
 
 .. _central-submissions-overview:
@@ -151,6 +152,29 @@ If you want to use the free and popular `R statistics and analysis tool <https:/
   If you are having trouble getting Power BI to connect to Central, and especially if you see error messages about permissions or authentication, try `resetting the Power BI cached credentials <https://community.powerbi.com/t5/Power-Query/Power-BI-Web-cached-credentials-For-OData/m-p/126826/highlight/true#M8228>`_.
 
 You can also access the OData feed yourself. The OData feed is an easily consumable JSON data format and offers a metadata schema, some filtering and paging options, and more. To learn more about the OData feed, click the :guilabel:`API Access` button or see the `developer documentation <https://odkcentral.docs.apiary.io/#reference/odata-endpoints>`_ directly.
+
+.. _central-submissions-media-downloads:
+
+Setting up Media Downloads
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For a lot of reasons, it can be tricky to access submission media files while doing data analysis. Getting an analysis tool to fetch data from Central does not mean it can or knows how to get images, video, and other media.
+
+In OData data responses, you will see media files given by their filename. If you want, you can construct a link within your analysis tool that will download any media file with your web browser. You can do this by gluing together pieces of text into a URL. Often this gluing operation is called ``concat`` or ``concatenate``. You'll need to make it look like this:
+
+  .. code-block:: console
+
+    https://DOMAIN/dl/projects/PROJECTID/forms/FORMID/submissions/INSTANCEID/attachments/FILENAME
+
+Where the uppercase words need to be replaced with the appropriate values. The easiest way to get the ``DOMAIN``, ``PROJECTID``, and ``FORMID`` is to open the Form in your web browser in the Central administration website and just copy the values you see there. The two web addresses are quite similar. Then you have to add the ``INSTANCEID`` and the ``FILENAME``, both of which you can find in the OData data itself.
+
+Here is an example of a completed address:
+
+  .. code-block:: console
+
+    https://my.odk.server/dl/projects/1/forms/forest_survey/submissions/uuid:20bcee82-4a22-4381-a6aa-f926fc85fb22/attachments/my.file.mp3
+
+This location is a web page that causes a web browser to download a file. It cannot be used directly to embed images or video on any website or application.
 
 .. _central-submissions-review-states:
 

--- a/src/central-submissions.rst
+++ b/src/central-submissions.rst
@@ -80,16 +80,18 @@ To find the Form submissions page, first find the form in the Form listings page
 
 The table preview you see here will at first show you the first ten fields of your survey and their results, with the latest submissions shown closest to the top. Any downloadable files will appear with a green download link you can use to directly download that media attachment. The submission's instance ID will always be shown at the right side of this preview table.
 
-If your form has more than ten fields, you can show more columns by accessing the :guilabel:`Columns shown` dropdown and checking the columns you wish to see. While the Columns shown pane is open, you can use the search box or your browser's search feature (usually Ctrl+F or Cmd+F) to search for particular column name if you have many.
+If your form has more than ten fields, you can show more columns by accessing the :guilabel:`Columns shown` dropdown and checking the columns you wish to see. While the Columns shown pane is open, you can use the search box along its top to search for a particular column name if you have many.
 
-You can limit the rows that appear by the submission author and the date. These filter controls are available just above the submission table.
+In the :guilabel:`State and actions` column, you will see the current review state of each submission and the number of edits that have been made, if any. If a submission is missing expected media uploads, you will see a warning here. When you hover over a row (or **tab** to it with your keyboard) you will see controls in this column to edit the submission, or see more details about it. You can read more about :ref:`review states <central-submissions-review-states>` and the :ref:`submission detail page <central-submissions-details>` below.
 
-It is not yet possible to screen or delete submissions for quality or edit submission data. These features are planned for future releases. For now, you will need to pull your data out of Central before you can work with it. Right now, you can do this in one of two ways:
+You can limit the rows that appear by the submission author, the date, and the review status. These filter controls are available just above the submission table.
+
+Any filter you apply to the submission table also applies to the download button. To work with your data, you can download it from Central. Right now, you can do this in one of two ways:
 
 1. The **CSV Download** option will get you a :file:`.zip` file containing one or more :file:`.csv` tables, along with any multimedia submitted to the form. This is a good option if you already have custom tools you wish to use, or you want to import it into an offline analysis tool like SPSS or Stata.
 2. The **OData connector** allows you connect a live representation of the data to OData-capable tools like Microsoft Excel, Microsoft Power BI, Tableau, SAP, and others. This option has some advantages: the data is transferred more richly to maintain more data format information, and the feed is always live, meaning any analysis or reports you perform in your tool over an OData connection can be easily refreshed as more submissions come in.
 
-When the table has been filtered by submission author or date, that filter also applies to the downloads. This makes it possible to download partial sections of your data at once.
+When the rows of the table have been filtered in any way, that filter also applies to the downloads. This makes it possible to download partial sections of your data at once.
 
 Learn more about these options below:
 
@@ -102,7 +104,9 @@ To download all submission data as a :file:`.zip` of :file:`.csv` tables, click 
 
    .. image:: /img/central-submissions/download-button.png
 
-Once it completes downloading, you will find one or more files when you extract it:
+If you have any row filters applied to the submission table, those filters will be applied to your download as well. You can use this to, for example, download only submissions from a particular month, or only approved submissions.
+
+Once the archive completes downloading, you will find one or more files when you extract it:
 
  - A root table :file:`.csv` named after your Form title.
  - Join table :file:`.csv` files representing any repeats you may have in your form, with join columns on the left of each table relating each row to its counterpart in the parent table. Each join table is named to reflect its relationship with the others. If there is only one :file:`.csv` file, then your form has no repeats.
@@ -142,4 +146,53 @@ To connect with Excel or Power BI, follow these steps.
   See `Import external data into Excel <https://support.office.com/en-us/article/connect-to-an-odata-feed-power-query-4441a94d-9392-488a-a6a9-739b6d2ad500>`_ and `OData feeds in Power BI <https://docs.microsoft.com/en-us/power-bi/desktop-connect-odata>`_ for more information.
 
 If you want to use the free and popular `R statistics and analysis tool <https://www.r-project.org/>`_, we recommend you use `ruODK <https://docs.ropensci.org/ruODK/>`_. A guide for getting started with it can be found `here <https://docs.ropensci.org/ruODK/articles/odata-api.html>`_. ruODK is developed and supported by community members. If you wish to help improve it, you can find information `on GitHub <https://docs.ropensci.org/ruODK/CONTRIBUTING.html>`_.
+
+.. tip::
+  If you are having trouble getting Power BI to connect to Central, and especially if you see error messages about permissions or authentication, try `resetting the Power BI cached credentials <https://community.powerbi.com/t5/Power-Query/Power-BI-Web-cached-credentials-For-OData/m-p/126826/highlight/true#M8228>`_.
+
+You can also access the OData feed yourself. The OData feed is an easily consumable JSON data format and offers a metadata schema, some filtering and paging options, and more. To learn more about the OData feed, click the :guilabel:`API Access` button or see the `developer documentation <https://odkcentral.docs.apiary.io/#reference/odata-endpoints>`_ directly.
+
+.. _central-submissions-review-states:
+
+Submission Review States
+------------------------
+
+As of version 1.2, Central allows Project Managers and Administrators to review submissions and assign them certain states. This optional feature lets you perform verification and data correction within Central itself. The available states are:
+
++------------+-------------+-----------------------------------------------------------------------------------+
+| State      | Assigned by | Description                                                                       |
++============+=============+===================================================================================+
+| Received   | System      | The default state for all incoming submissions, assigned automatically by Central |
++------------+-------------+-----------------------------------------------------------------------------------+
+| Edited     | System      | Automatically assigned by Central whenever a submission is edited by any user     |
++------------+-------------+-----------------------------------------------------------------------------------+
+| Has Issues | User        | Can be assigned by project staff if a submission has problems                     |
++------------+-------------+-----------------------------------------------------------------------------------+
+| Approved   | User        | Can be assigned by project staff to approve a submission                          |
++------------+-------------+-----------------------------------------------------------------------------------+
+| Rejected   | User        | Can be assigned by project staff to reject a submission                           |
++------------+-------------+-----------------------------------------------------------------------------------+
+
+The ``Received`` and ``Edited`` states are automatically set by Central any time a submission is uploaded or edited. The other states are assigned by project staff. Review states have suggested meanings, but *they do not do anything by themselves*. You are free to use these states however you'd like.
+
+Once submissions have been reviewed, the submission table download and the OData connection both allow submissions to be filtered by review state. This lets you, for example, download only all the approved submissions.
+
+.. _central-submissions-details:
+
+Submission Details
+------------------
+
+As of version 1.2, each submission has its own detail page which provides basic information about the submission, an activity history of action and discussion on that submission, and tools for updating the submission review state and data itself.
+
+   .. image:: /img/central-submissions/details.png
+
+The title at the top is pulled from the ``instanceName`` metadata tag if there is one, otherwise it will be the ``instanceID``. You can set up your form to compute an ``instanceName`` based on the data in each submission. You may want to do this if you plan on using this page a lot, because it makes navigation much easier to have friendly names at the top of the page and in the web browser title and tab.
+
+Basic detail can be found along the left. If there are expected media attachments for this submission, that status information will be provided.
+
+The main activity feed on the right shows you the discussion and action history of the submission. Any review state changes, comments, and edits will appear here. At the top of the activity feed, you can :guilabel:`Review` a submission to assign a new review state, :guilabel:`Edit` the submission directly using Enketo in your web browser, or type in the box to begin leaving a comment.
+
+You can leave a note when you update the review state, to indicate why the decision is being made, or any other information you'd like saved.
+
+Any time a user makes a submission edit, they will see a loud note when they are returned to this detail page suggesting that they leave a comment describing the edits they have made. This is optional but highly encouraged. In a future version of Central, greater detail will be automatically provided about the data values that were changed.
 

--- a/src/central-submissions.rst
+++ b/src/central-submissions.rst
@@ -84,7 +84,7 @@ If your form has more than ten fields, you can show more columns by accessing th
 
 In the :guilabel:`State and actions` column, you will see the current review state of each submission and the number of edits that have been made, if any. If a submission is missing expected media uploads, you will see a warning here. When you hover over a row (or **tab** to it with your keyboard) you will see controls in this column to edit the submission, or see more details about it. You can read more about :ref:`review states <central-submissions-review-states>` and the :ref:`submission detail page <central-submissions-details>` below.
 
-You can limit the rows that appear by the submission author, the date, and the review status. These filter controls are available just above the submission table.
+You can limit the rows that appear by the submitter, the date, and the review status. These filter controls are available just above the submission table.
 
 Any filter you apply to the submission table also applies to the download button. To work with your data, you can download it from Central. Right now, you can do this in one of two ways:
 
@@ -106,7 +106,7 @@ To download all submission data as a :file:`.zip` of :file:`.csv` tables, click 
 
 If you have any row filters applied to the submission table, those filters will be applied to your download as well. You can use this to, for example, download only submissions from a particular month, or only approved submissions.
 
-Once the archive completes downloading, you will find one or more files when you extract it:
+Once the :file:`.zip` completes downloading, you will find one or more files when you extract it:
 
  - A root table :file:`.csv` named after your Form title.
  - Join table :file:`.csv` files representing any repeats you may have in your form, with join columns on the left of each table relating each row to its counterpart in the parent table. Each join table is named to reflect its relationship with the others. If there is only one :file:`.csv` file, then your form has no repeats.
@@ -157,7 +157,7 @@ You can also access the OData feed yourself. The OData feed is an easily consuma
 Submission Review States
 ------------------------
 
-As of version 1.2, Central allows Project Managers and Administrators to review submissions and assign them certain states. This optional feature lets you perform verification and data correction within Central itself. The available states are:
+As of version 1.2, Central allows Project Managers and Administrators to review submissions and assign them certain states. This feature lets you perform verification and follow-up data editing within Central itself, if you need this kind of a workflow. The available states are:
 
 +------------+-------------+-----------------------------------------------------------------------------------+
 | State      | Assigned by | Description                                                                       |
@@ -173,7 +173,7 @@ As of version 1.2, Central allows Project Managers and Administrators to review 
 | Rejected   | User        | Can be assigned by project staff to reject a submission                           |
 +------------+-------------+-----------------------------------------------------------------------------------+
 
-The ``Received`` and ``Edited`` states are automatically set by Central any time a submission is uploaded or edited. The other states are assigned by project staff. Review states have suggested meanings, but *they do not do anything by themselves*. You are free to use these states however you'd like.
+The ``Received`` and ``Edited`` states are automatically set by Central any time a submission is uploaded or edited. The other states are assigned by project staff. We suggest some meanings for these states above, but they don't cause anything to happen automatically. For example, rejected submissions will still be included in your data exports unless you filter them out yourself. So, you are free to use these states however you'd like.
 
 Once submissions have been reviewed, the submission table download and the OData connection both allow submissions to be filtered by review state. This lets you, for example, download only all the approved submissions.
 
@@ -190,9 +190,18 @@ The title at the top is pulled from the ``instanceName`` metadata tag if there i
 
 Basic detail can be found along the left. If there are expected media attachments for this submission, that status information will be provided.
 
-The main activity feed on the right shows you the discussion and action history of the submission. Any review state changes, comments, and edits will appear here. At the top of the activity feed, you can :guilabel:`Review` a submission to assign a new review state, :guilabel:`Edit` the submission directly using Enketo in your web browser, or type in the box to begin leaving a comment.
+The main activity feed on the right shows you the discussion and action history of the submission. Any review state changes, comments, and edits will appear here. At the top of the activity feed, you can :guilabel:`Review` a submission to assign a new review state, :guilabel:`Edit` the submission directly in your web browser, or type in the box to begin leaving a comment.
 
 You can leave a note when you update the review state, to indicate why the decision is being made, or any other information you'd like saved.
 
-Any time a user makes a submission edit, they will see a loud note when they are returned to this detail page suggesting that they leave a comment describing the edits they have made. This is optional but highly encouraged. In a future version of Central, greater detail will be automatically provided about the data values that were changed.
+.. _central-submissions-editing:
+
+Submission Editing
+------------------
+
+From the :ref:`submission detail page <central-submissions-details>` you can press the :guilabel:`Edit` button to edit the submission in your web browser. When an edited submission is resubmitted, a new version of it is created, just like a form version. You will be able to see previous submission versions in a future version of Central.
+
+Any time a user edits a submission, they will see a note when they are returned to the detail page suggesting that they leave a comment describing the edits they have made. This is optional but highly encouraged. In a future version of Central, greater detail will be automatically provided about the data values that were changed.
+
+Finally, when edits are submitted, the submission :ref:`review state <central-submissions-review-states>` will automatically be set to :guilabel:`Edited`.
 

--- a/src/central-submissions.rst
+++ b/src/central-submissions.rst
@@ -164,7 +164,7 @@ In OData data responses, you will see media files given by their filename. If yo
 
   .. code-block:: console
 
-    https://DOMAIN/dl/projects/PROJECTID/forms/FORMID/submissions/INSTANCEID/attachments/FILENAME
+    https://DOMAIN/#/dl/projects/PROJECTID/forms/FORMID/submissions/INSTANCEID/attachments/FILENAME
 
 Where the uppercase words need to be replaced with the appropriate values. The easiest way to get the ``DOMAIN``, ``PROJECTID``, and ``FORMID`` is to open the Form in your web browser in the Central administration website and just copy the values you see there. The two web addresses are quite similar. Then you have to add the ``INSTANCEID`` and the ``FILENAME``, both of which you can find in the OData data itself.
 
@@ -172,7 +172,7 @@ Here is an example of a completed address:
 
   .. code-block:: console
 
-    https://my.odk.server/dl/projects/1/forms/forest_survey/submissions/uuid:20bcee82-4a22-4381-a6aa-f926fc85fb22/attachments/my.file.mp3
+    https://my.odk.server/#/dl/projects/1/forms/forest_survey/submissions/uuid:20bcee82-4a22-4381-a6aa-f926fc85fb22/attachments/my.file.mp3
 
 This location is a web page that causes a web browser to download a file. It cannot be used directly to embed images or video on any website or application.
 

--- a/src/central-upgrade.rst
+++ b/src/central-upgrade.rst
@@ -40,5 +40,30 @@ The quickest way to do this is to run ``ufw disable`` while logged into your ser
 
   If you don't want to disable the firewall entirely, you can instead configure Docker, ``iptables``, and ``ufw`` yourself. This can be really difficult to do correctly, so we don't recommend most people try. Another option is to use an upstream network firewall.
 
-  The goal here is to ensure that it is possible to access the host through its external IP from within each Docker container. In particular, if you can successfully ``curl`` your Central website over HTTPS on its public domain name, all Enketo features should work correctly.
+  The goal here is to ensure that it is possible to access the host through its external IP from within each Docker container. In particular, if you can successfully ``curl`` your Central website over HTTPS on its public domain name from within the Enketo container, all Enketo features should work correctly.
+
+.. _central-upgrade-1.2:
+
+Upgrading to Central 1.2
+------------------------
+
+In version 1.2, we added some advanced features to Central's server configuration. These features will not be meaningful to most users. However, because we would like to make this change and further improvements in the future, we have modified the template ``.env`` configuration file you set up during installation.
+
+Since you have made your own changes to the ``.env`` file to set Central up for your environment, you will see an error message when you run the ``git pull`` command:
+
+.. code-block:: console
+
+ error: Your local changes to the following files would be overwritten by merge:
+         .env
+ Please commit your changes or stash them before you merge.
+
+Don't worry, nothing bad happens if you see this. To get around this error, run this set of commands instead of ``git pull``:
+
+.. code-block:: console
+
+ mv .env swap
+ git pull
+ mv swap .env
+
+Afterwards, ``git status`` should not say anything about the ``.env`` file at all. If it does, copy and paste your entire console session into a `forum thread <https://forum.getodk.org/c/support/6>`_ and someone will help you out.
 

--- a/src/img/central-install/nano.png
+++ b/src/img/central-install/nano.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:38b4606af7b6e028c5d1e04aeeb8d080e86c3409c406f80f5ea9a470cedd4514
-size 216997
+oid sha256:c31373805ac5f0f23331352a0c0ae7e83c964a43d744e056db93265cf020acb8
+size 53591

--- a/src/img/central-submissions/details.png
+++ b/src/img/central-submissions/details.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33637874252bfeec40583046227e541e808b3420ab63f12c58e66d8563259bdb
+size 160499

--- a/src/img/central-submissions/download-button.png
+++ b/src/img/central-submissions/download-button.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5a08ab8327d8aa024ccd037aa19f2106f3c9fa642e5e84d6b7a5f187190445c8
-size 72599
+oid sha256:93a3b6546db9354f8c256399e9ba2af1e0e572ca162d084d24c89bbf1934035c
+size 133126

--- a/src/img/central-submissions/listing.png
+++ b/src/img/central-submissions/listing.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fff3006539ac3462508e47e92d3f8b8498b815afe2a5ab8f9e78c8c85924bbf9
-size 189792
+oid sha256:8bb3e2b4488747c27e6dd49148eb020cd8c674807e7a4efe660daf14e4538f0b
+size 132518

--- a/src/img/central-submissions/new.png
+++ b/src/img/central-submissions/new.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5f6ab3ffcabc22b66cf4a41b69af8163726d5733c6f092b7b4ff6a472e10fcbd
-size 108001
+oid sha256:e0c32f87458ea8b266b690544f4cbed3f6fef86ae5f410d6f2786a931778ee10
+size 80808

--- a/src/img/central-submissions/odata-button.png
+++ b/src/img/central-submissions/odata-button.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5df9a86c4f8095e238ccf5a7277a1ce2d7431b86a211e1816687adb4eda2b120
-size 72566
+oid sha256:788c8936714dffa161c237c15b1355a45aa87f23a97a27be997fbe6f9241df66
+size 80729


### PR DESCRIPTION
the three commits describe what happens here:

1. update the `.env` and install documentation to account for those changes.
2. update the submissions docs w newer screenshots, and add information about the new details page and features.
3. update the audit log actions list.

anything i missed?