### PR TITLE
Provide general introduction to XLSForm, add starter template

### DIFF
--- a/src/collect-settings.rst
+++ b/src/collect-settings.rst
@@ -224,6 +224,8 @@ Specifies how blank forms should be updated:
   When enabled, forms are sent immediately when they are finalized, if the device can connect to the internet. If an internet connection is not available at the time of finalization, your finalized forms will be queued to send as soon as connectivity is established.
   You can specify whether to send over WiFi, cellular data, or both.
 
+.. delete-after-send:
+
 :guilabel:`Delete after send`
 """"""""""""""""""""""""""""""
   When enabled, form instances are deleted once they are sent.

--- a/src/collect-settings.rst
+++ b/src/collect-settings.rst
@@ -224,7 +224,7 @@ Specifies how blank forms should be updated:
   When enabled, forms are sent immediately when they are finalized, if the device can connect to the internet. If an internet connection is not available at the time of finalization, your finalized forms will be queued to send as soon as connectivity is established.
   You can specify whether to send over WiFi, cellular data, or both.
 
-.. delete-after-send:
+.. _delete-after-send:
 
 :guilabel:`Delete after send`
 """"""""""""""""""""""""""""""

--- a/src/collect-settings.rst
+++ b/src/collect-settings.rst
@@ -109,7 +109,11 @@ To access User Interface settings:
 
 :guilabel:`Language`
 """""""""""""""""""""
-  Forces the Collect interface to use a specific language. By default, Collect matches the device language. Note that this only sets the language for the Collect interface and not for form contents. For multi-language forms, the form language is set :ref:`while filling out that form <change-form-language>`. The Collect translations are provided by the ODK community through the `Transifex service <https://www.transifex.com/getodk/collect/>`_. You can join Transifex to add or correct translations in your language.
+  Forces the Collect interface to use a specific language. By default, Collect matches the device language. Note that this only sets the language for the Collect user interface and not for the form. For :doc:`forms with multiple languages <form-language>`, the form language is set :ref:`while filling out the form <change-form-language>`. 
+
+  .. note::
+
+    Collect's translations are provided by the ODK community through the `Transifex service <https://www.transifex.com/getodk/collect/>`_. You can join Transifex to add or correct translations in your language.
 
 :guilabel:`Text font size`
 """"""""""""""""""""""""""""

--- a/src/encrypted-forms.rst
+++ b/src/encrypted-forms.rst
@@ -2,9 +2,7 @@
 Encrypted Forms
 *****************************
 
-.. seealso::
-
-ODK Central can :ref:`manage encryption for your projects <central-encryption-modes>`.
+.. seealso:: ODK Central can :ref:`manage encryption for your projects <central-encryption-modes>`.
 
 .. _encrypted-forms:
 

--- a/src/encrypted-forms.rst
+++ b/src/encrypted-forms.rst
@@ -8,9 +8,9 @@ Encrypted Forms
 
 Overview
 ====================
-Encrypted forms provide a mechanism to keep your data private even when using **http:** for communications (for example, when you do not have an **SSL certificate** or **https:** is not available). Encrypted forms may also enable Google App Engine deployments (and deployments using other web database services, such as, AWS) to comply with data privacy laws, eliminating the necessity for setting up your own servers to meet those requirements.
+Encrypted forms provide a mechanism to keep your data private even when using **http:** for communications (for example, when you do not have an **SSL certificate** or **https:** is not available). Encrypted forms may also enable deployments using cloud providers to comply with data privacy laws, eliminating the necessity for setting up your own servers to meet those requirements.
 
-Encrypted forms apply asymmetric public key encryption at the time the form is finalized within ODK Collect. This encrypted form can then be submitted to a server. ODK Central provides `a managed encryption option <central-encryption>` which means a decrypted data file can securely be downloaded without using any other tool. Central self-managed encryption and other servers require using ODK Briefcase to download and decrypt the data. Briefcase, when supplied with the asymmetric private key (which Briefcase never stores), can then decrypt and export the form data as a CSV file for your use.
+Encrypted forms apply asymmetric public key encryption at the time the form is finalized within ODK Collect. This encrypted form can then be submitted to a server. ODK Central provides :ref:`a managed encryption option <central-encryption>` which means a decrypted data file can securely be downloaded without using any other tool. Central self-managed encryption and other servers require using ODK Briefcase to download and decrypt the data. Briefcase, when supplied with the asymmetric private key (which Briefcase never stores), can then decrypt and export the form data as a CSV file for your use.
 
 The finalized form's data (and media attachments) are encrypted before being submitted to a server and remain encrypted while stored on the server. When using Briefcase, the data remains encrypted as it is pulled, where it is again stored in encrypted form.
 
@@ -19,13 +19,13 @@ The finalized form's data (and media attachments) are encrypted before being sub
   - A server cannot present or share the data with another service since the encryption obscures the entire contents of the form and the server never possesses the asymmetric key required to decrypt the form.
   - When using encrypted forms, the server serves only as a data aggregation point.
 
-The non-encrypted data is available on the ODK Collect device during data collection and whenever a form is saved without marking it as complete. Once you mark a form as complete (finalize it), Collect will generate a random 256-bit symmetric key, encrypt the form contents and all attachments with this key, then construct a submission manifest which describes the encrypted submission and an asymmetric-key encryption of the symmetric key used for the encryption. This manifest is the "form" that is uploaded to a server, with the encrypted form contents and its encrypted attachments appearing as attachments to this submission manifest "form."
+The non-encrypted data is available on the Collect device during data collection and whenever a form is saved without marking it as complete. Once you mark a form as complete (finalize it), Collect will generate a random 256-bit symmetric key, encrypt the form contents and all attachments with this key, then construct a submission manifest which describes the encrypted submission and an asymmetric-key encryption of the symmetric key used for the encryption. This manifest is the "form" that is uploaded to a server, with the encrypted form contents and its encrypted attachments appearing as attachments to this submission manifest "form."
 
 .. _security-concerns:
 
 Security Concerns
 ====================
-While ODK Collect attempts to remove all unencrypted copies of a finalized form and its attachments from the device, because ODK Collect uses third-party applications for image capture, etc., and because of the potential for Forced Close events during the clean-up process, we cannot guarantee that all copies will have been destroyed. Furthermore, because of the way an SD card writes and deletes information, there is a possibility of this data being recoverable from the free space on the SD card. Your organization should investigate the extra steps needed to ensure all data is deleted from the SD cards on your ODK Collect devices and should establish procedures to periodically wipe and reinstall those devices.
+While Collect attempts to remove all unencrypted copies of a finalized form and its attachments from the device, because Collect uses third-party applications for image capture, etc., and because of the potential for Forced Close events during the clean-up process, we cannot guarantee that all copies will have been destroyed. Furthermore, because of the way an SD card writes and deletes information, there is a possibility of this data being recoverable from the free space on the SD card. Your organization should investigate the extra steps needed to ensure all data is deleted from the SD cards on your Collect devices and should establish procedures to periodically wipe and reinstall those devices.
 
 .. note::
 
@@ -125,7 +125,7 @@ This may also complain about a missing configuration file. You can ignore this w
 Storing and using the keys
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Move the :file:`MyPrivateKey.pem` file to a secure location. It does not have a password encoding it, so anyone can decrypt your data if they have access to this file. This is the private key file that you will give to ODK Briefcase when decrypting the data.
+Move the :file:`MyPrivateKey.pem` file to a secure location. It does not have a password encoding it, so anyone can decrypt your data if they have access to this file. This is the private key file that you will give to Briefcase when decrypting the data.
 
 .. _update-keys:
 
@@ -153,8 +153,8 @@ Open the :file:`MyPublicKey.pem` file and copy the resulting very-long string in
 Operations
 ===========================
 
-Operationally, you would add the form definition to the server identified in the ``<submission>`` tag's action attribute, and deploy everything using Collect, figure out how you want to implement a periodic SD Card wiping protocol for your devices, and you're done. Submissions will be encrypted when marked as complete. Once the data is on your server, use :doc:`Briefcase <briefcase-intro>` to download the encrypted submissions to your desktop computer, and then specify the private key PEM file when decrypting and generating the CSV files.
+Operationally, you would add the form definition to the server identified in the ``<submission>`` tag's action attribute, and deploy everything using Collect, figure out how you want to implement a periodic SD card wiping protocol for your devices, and you're done. Submissions will be encrypted when marked as complete. Once the data is on your server, use :doc:`Briefcase <briefcase-intro>` to download the encrypted submissions to your desktop computer, and then specify the private key PEM file when decrypting and generating the CSV files.
 
 .. note::
-  - ODK Central or ODK Aggregate will only hold the encrypted submission with no access to the private key
-  - ODK Briefcase will emit the CSV with an extra final column that indicates whether the signature of the encrypted file was good or bad.  It would be bad if any of the attachments are missing or if there was tampering (other than the wholesale replacement of a submission, which can't be detected).
+  - Central or Aggregate will only hold the encrypted submission with no access to the private key
+  - Briefcase will emit the CSV with an extra final column that indicates whether the signature of the encrypted file was good or bad.  It would be bad if any of the attachments are missing or if there was tampering (other than the wholesale replacement of a submission, which can't be detected).

--- a/src/form-design-intro.rst
+++ b/src/form-design-intro.rst
@@ -1,19 +1,19 @@
 Intro to Forms in ODK
 ========================
 
-Forms provide a structured way to collect and provide information. Typically forms are used by :term:`enumerators <enumerator>` who ask questions of and share information with :term:`participants <participant>`. :ref:`Web forms <central-submissions-public-link>` can also be used for self-report. 
+Forms provide a structured way to collect and provide information. Typically forms are used by data collectors (also called enumerators) who ask questions of and share information with participants. :ref:`Web forms <central-submissions-public-link>` can also be used for self-report. 
 
 ODK forms can be used to do things like:
 
-- Collect data about people in a pre-determined set of households
-- Collect data about plant species in a particular area at different points in time
-- Collect audio of animal sounds for later identification
-- Guide community health workers through a diagnosis protocol
-- Deliver tailored video-based agricultural training content based on a farmer's responses to questions
+- Conduct a socioeconomic survey of households
+- Collect geo-tagged plant species data at different points in time
+- Record video and audio of wild animals for later identification
+- Guide health workers through a medical triage protocol in multiple languages
+- Deliver video-based agricultural training based on a farmer's responses to questions
 
-Forms are composed of fields of different types which can each collect or display one piece of information. Visible fields generally represent questions and are :doc:`displayed differently <form-question-types>` based on their type. Questions can be :ref:`grouped together <groups>` including :ref:`on one screen <field-list>`. They can also be :ref:`repeated <repeats>`.
+Forms are made of fields of  :doc:`different types <form-question-types>` which can each collect or display one piece of information. Visible fields generally represent questions and are displayed differently based on their type.
 
-:doc:`Form logic <form-logic>`, :doc:`datasets <form-datasets>` and :ref:`hidden fields <hidden-questions>` make it possible to create forms that represent complex processes.
+Questions can be :ref:`grouped together <groups>` including :ref:`on one screen <field-list>`. They can also be :ref:`repeated <repeats>`. :doc:`Form logic <form-logic>`, :doc:`datasets <form-datasets>`, :ref:`hidden fields <hidden-questions>`, and :doc:`external apps <launch-apps-from-collect>` make it possible to create easy-to-use, but powerful forms that represent complex processes. 
 
 .. _excel-based-form-creation:
 
@@ -29,7 +29,7 @@ Drag-and-drop form creation
   
 For simple forms, :doc:`build-intro` is a drag-and-drop form designer that works both online and offline.
 
-Technical details
-------------------
 
-The form creation tools described above convert user-friendly form definitions into XML. Form rendering or processing tools in the ODK ecosystem use XML form definitions following the `ODK XForms specification <https://getodk.github.io/xforms-spec/>`_, a subset of the `W3C XForms specification <https://www.w3.org/TR/xforms/>`_.
+.. note::
+
+  The ODK ecosystems use XML form definitions following the `ODK XForms specification <https://getodk.github.io/xforms-spec/>`_, a subset of the `W3C XForms specification <https://www.w3.org/TR/xforms/>`_. The form creation tools described above convert user-friendly form definitions into XML.

--- a/src/form-design-intro.rst
+++ b/src/form-design-intro.rst
@@ -1,26 +1,26 @@
 Intro to Forms in ODK
 ========================
 
-Forms used in the ODK ecosystem are XML documents following the `ODK XForms specification <https://getodk.github.io/xforms-spec/>`_, a subset of the `W3C XForms specification <https://www.w3.org/TR/xforms/>`_. (`Example XForms are available for reference. <https://github.com/getodk/sample-forms>`_)
+Forms provide a structured way to collect and provide information. Typically forms are used by :term:`enumerators <enumerator>` who ask questions of and share information with :term:`participants <participant>`. :ref:`Web forms <central-submissions-public-link>` can also be used for self-report. 
 
-Most ODK tools use the `ODK JavaRosa <https://github.com/getodk/javarosa>`_ library to render forms. Form transfer between ODK components is governed by the :doc:`openrosa` API.
+ODK forms can be used to do things like:
 
-Because of the complexity of the XForms format, we do not recommend coding XForms directly in XML. The recommended process is:
+- Collect data about people in a pre-determined set of households
+- Collect data about plant species in a particular area at different points in time
+- Collect audio of animal sounds for later identification
+- Guide community health workers through a diagnosis protocol
+- Deliver tailored video-based agricultural training content based on a farmer's responses to questions
 
-1. Begin with one of the :doc:`form-tools`.
-2. Edit the XML only if necessary.
+Forms are composed of fields of different types which can each collect or display one piece of information. Visible fields generally represent questions and are :doc:`displayed differently <form-question-types>` based on their type. Questions can be :ref:`grouped together <groups>` including :ref:`on one screen <field-list>`. They can also be :ref:`repeated <repeats>`.
 
-   - Before editing an XForm directly, you need to be familiar with the `ODK XForm specification <https://github.com/getodk/xforms-spec>`_.
-
-3. Use :doc:`validate` to check that the edited XForm is well-formed and fully compliant.
-
+:doc:`Form logic <form-logic>`, :doc:`datasets <form-datasets>` and :ref:`hidden fields <hidden-questions>` make it possible to create forms that represent complex processes.
 
 .. _excel-based-form-creation:
 
 Excel-based form creation
 -------------------------
 
-Most ODK users design their forms in Excel using :doc:`xlsform`.
+Most ODK users design their forms in Excel or Google Sheets using :doc:`XLSForm <xlsform>`. Examples in this documentation use XLSForm notation to show form features.
 
 .. _drag-and-drop-form-creation:
 
@@ -28,3 +28,8 @@ Drag-and-drop form creation
 ---------------------------
   
 For simple forms, :doc:`build-intro` is a drag-and-drop form designer that works both online and offline.
+
+Technical details
+------------------
+
+The form creation tools described above convert user-friendly form definitions into XML. Form rendering or processing tools in the ODK ecosystem use XML form definitions following the `ODK XForms specification <https://getodk.github.io/xforms-spec/>`_, a subset of the `W3C XForms specification <https://www.w3.org/TR/xforms/>`_.

--- a/src/form-language.rst
+++ b/src/form-language.rst
@@ -32,7 +32,7 @@ All columns representing user-facing text or media can be multi-lingual:
  - :th:`required_message`
 
 Each language column adds two colons and the language name,
-followed by the `two letter language code` in parenthesis.
+followed by the `two letter language code` in parentheses.
 
 For example:
 
@@ -47,7 +47,6 @@ For example:
   If you would like Collect's user interface to support your language,
   contribute translations at https://www.transifex.com/getodk.
 
-.. _XLSForm: http://xlsform.org
 .. _two letter language code: http://www.iana.org/assignments/language-subtag-registry/language-subtag-registry
 
 .. rubric:: XLSForm --- Single language
@@ -125,8 +124,16 @@ For example:
 Switching languages
 ---------------------
 
-Typically, if multiple languages are available on a form,
-the form will display in the language set on the device.
+If your form defines multiple languages and you know most of your data collectors will need to use the same one, you should set an explicit default language. You can do this in your XLSForm's **settings** sheet:
+
+.. rubric:: XLSForm --- setting a default language
+
+.. csv-table:: settings
+  :header: form_id, version, default_language
+
+  my_form, 2024050301, Español (es)
+
+Otherwise, Collect will default to the first language defined.
 
 To switch between available languages on a form,
 go to :menuselection:`⋮ --> Change Language`.

--- a/src/form-language.rst
+++ b/src/form-language.rst
@@ -18,9 +18,7 @@
 Form Language
 ===================
 
-:doc:`collect-intro` and `XLSForm`_ support `multi-language forms`_.
-
-.. _multi-language forms: http://xlsform.org/#language
+:doc:`collect-intro` and :doc:`XLSForm <xlsform>` support multi-language forms.
 
 To add additional languages to your XLSForm,
 add columns of user-facing content with language-specific columns.

--- a/src/form-language.rst
+++ b/src/form-language.rst
@@ -21,9 +21,7 @@ Form Language
 :doc:`collect-intro` and :doc:`XLSForm <xlsform>` support multi-language forms.
 
 To add additional languages to your XLSForm,
-add columns of user-facing content with language-specific columns.
-
-All columns representing user-facing text or media can be multi-lingual:
+add columns of user-facing content with language-specific columns. All columns representing user-facing text or media can be multi-lingual:
 
  - :th:`label`
  - :th:`hint`
@@ -32,9 +30,7 @@ All columns representing user-facing text or media can be multi-lingual:
  - :th:`required_message`
 
 Each language column adds two colons and the language name,
-followed by the `two letter language code` in parentheses.
-
-For example:
+followed by the `two letter language code <http://www.iana.org/assignments/language-subtag-registry/language-subtag-registry>`_ in parentheses. For example:
 
 - :th:`label::English (en)`
 - :th:`hint::French (fr)`
@@ -43,11 +39,7 @@ For example:
 .. note::
 
   The text shown in Collect's user interface (e.g., buttons, menus, dialogs)
-  is controlled by device language, not the form language.
-  If you would like Collect's user interface to support your language,
-  contribute translations at https://www.transifex.com/getodk.
-
-.. _two letter language code: http://www.iana.org/assignments/language-subtag-registry/language-subtag-registry
+  is controlled by application, not the form. See :ref:`user interface settings <interface-settings>` for how to change the interface language.
 
 .. rubric:: XLSForm --- Single language
 

--- a/src/form-logic.rst
+++ b/src/form-logic.rst
@@ -695,8 +695,10 @@ To group questions, use the :tc:`begin_group...end_group` syntax.
   text, question_2, These questions will both be grouped together
   end_group, ,
 
+You can use the :tc:`field-list` appearance on a group to :ref:`display multiple questions on the same screen <field-list>`.
+
 If given a :th:`label`, groups will be visible in the form path to help orient the user
-(e.g. :guilabel:`My text widgets > Text widget 1`). Labeled groups will also be visible as clickable items in the jump menu:
+(e.g. :guilabel:`My text widgets > Text widget 1`). Labeled groups will also be visible as clickable items in the :ref:`jump menu <jumping>`:
 
 .. image:: /img/form-logic/jump-menu-groups.*
   :alt: The jump menu with a few grouped questions.

--- a/src/form-question-types.rst
+++ b/src/form-question-types.rst
@@ -2424,10 +2424,7 @@ To do this, put your select questions in a :tc:`field-list` group and use the fo
 Hidden questions
 ------------------
 
-Not all question types render as visible widgets in Collect.
-These questions do collect and store values,
-which are accessible as :ref:`variables <variables>`
-and available in Aggregate and other data analysis tools.
+Not all question types render as visible widgets in Collect. Hidden fields collect and store values which are accessible as :ref:`variables <variables>` and available in :doc:`Central <central-intro>` and other data analysis tools.
 
 .. contents::
   :local:

--- a/src/xlsform.rst
+++ b/src/xlsform.rst
@@ -2,6 +2,8 @@
 
   xform
   xlsx
+  yyyymmddrr
+  th
 
 XLSForm
 =======

--- a/src/xlsform.rst
+++ b/src/xlsform.rst
@@ -8,12 +8,65 @@ XLSForm
 
 .. _xlsform-introduction:
 
-:dfn:`XLSForm` is a form standard created to help simplify the authoring of forms in Excel. XLSForms are simple to get started with but allow for the authoring of complex forms.
+:dfn:`XLSForm` is a standard for building forms in Excel. XLSForms are simple to get started with and can represent complex forms. They can be created and edited by any application that works with ``.xlsx`` documents. This means that they are portable and can leverage many useful features commonly available in spreadsheet applications such as formulas, comments and document versioning. Many users choose to use an online application such as Google Sheets or Excel for the web so that they can collaborate on or publicly share their forms.
 
-To design your form, refer to the `XLSForm form design documentation <http://xlsform.org/>`_. Once the form has been designed, :ref:`upload the form to Central <central-forms-upload>`.
+One way to get started is by downloading or making a copy of `this template <https://docs.google.com/spreadsheets/d/1v9Bumt3R0vCOGEKQI6ExUf2-8T72-XXp_CbKKTACuko>`_. You can hover over columns to see guidance about how to use them. `The All Widgets form definition <https://docs.google.com/spreadsheets/d/1af_Sl8A_L8_EULbhRLHVl8OclCfco09Hq2tqb9CslwQ>`_ shows examples of all of the different user-visible question types.
+
+The ODK documentation shows all form design examples as XLSForms and describes how XLSForms are used by ODK tools. There is also a general tutorial for building XLSForms on the `XLSForm website <http://xlsform.org/>`_.
+
+Once your form has been designed, you can :ref:`upload the XLSForm directly to Central <central-forms-upload>`.
 
 .. tip::
 
-  If your ODK server does not support have the latest XLSForm features or you need to temporarily preview a form in a browser, try `XLSForm Online <https://getodk.org/xlsform>`_.
+  If your ODK server does not have the latest XLSForm features or you need to temporarily preview a form in a browser, try `XLSForm Online <https://getodk.org/xlsform>`_.
 
   If you need to design XLSForms offline or your form has sensitive data that you'd rather not upload into XLSForm Online, use the `pyxform <https://github.com/XLSForm/pyxform>`_ command line tool.
+
+.. _survey-sheet:
+
+The survey sheet
+------------------
+
+At minimum, an XLSForm has a sheet named **survey** to describe the types and order of fields in a form. It must have these three columns:
+
+- :th:`type`: the type of the field represented by each row. Supported types and how they are displayed are described :doc:`here <form-question-types>`.
+- :th:`name`: the name of the field represented by each row. This name will be used in your data results. It may not contain spaces and must start with a letter or underscore. You should use a short, descriptive name and can use underscores to separate words. For example: ``date_of_birth``.
+- :th:`label`: the user-visible question text for the field represented by each row. For example: ``When was ${first_name} born?`` This text can optionally :ref:`reference other fields <variables>` or :doc:`have translations <form-language>`.
+
+The survey sheet can have many other columns to represent different :doc:`question types <form-question-types>` and :doc:`form logic <form-logic>`. You can see the most commonly-used columns in `this template <https://docs.google.com/spreadsheets/d/1v9Bumt3R0vCOGEKQI6ExUf2-8T72-XXp_CbKKTACuko>`_.
+
+.. _settings-sheet:
+
+The settings sheet
+--------------------
+
+You should also include a **settings** sheet to uniquely identify your form definition and its current version. The entire sheet is optional but we recommend specifying at least the following columns:
+
+- :th:`form_title`: The title that will be displayed by tools that list this form.
+- :th:`form_id`: The unique ID that identifies this form to tools that use it. It may not contain spaces and must start with a letter or underscore. You should use a short, descriptive name and can use underscores to separate words. For example: ``bench_inventory_2021``.
+- :th:`version`: The unique version code that identifies the current state of the form. A common convention is to use a format like yyyymmddrr. For example, 2017021501 is the 1st revision from Feb 15th, 2017.
+- :th:`instance_name`: An :ref:`expression <expressions>` that will be used to represent a specific filled form created from this form definition. For example, ``concat(${first_name}, ${age})``. :ref:`Learn more <instance-name>`.
+
+.. _instance-name:
+
+Naming filled forms
+~~~~~~~~~~~~~~~~~~~~~
+
+In an XLSForm's **settings** sheet, you can add an :th:`instance_name` column and specify an :ref:`expression <expressions>` to use a specific filled form's contents in its name. This name will be shown in several places to help guide data collection and analysis. You should pick a name that uniquely identifies the filled form and the data it had captured. For example:
+
+- If a single filled form represents data about a real-world thing like a person or park bench, your :th:`instance_name` expression should include some information to uniquely identify the thing like the person's name or the park bench's location and current status.
+- If a single filled form represents data about an observation, consider including the date and time of the observation in the :th:`instance_name` expression.
+- If your form definition includes a repeat, consider including the repeat count in the :th:`instance_name` expression.
+
+.. _instance-name-collect:
+
+Filled form names in Collect
+""""""""""""""""""""""""""""""
+
+Each filled form is identified by its :th:`instance_name` value in :doc:`Collect <collect-intro>`'s :guilabel:`Edit Saved Form`, :guilabel:`Send Finalized Form` and :guilabel:`View Sent Form` lists. 
+
+In workflows where forms have to be be filled in multiple different steps, a useful :th:`instance_name` expression will make it much easier to find which filled form to edit. If forms only have to be edited under certain conditions (e.g. not all household members were available), you can include this status in the :th:`instance_name`.
+
+In the :guilabel:`View Sent Form` list, :th:`instance_name` can be helpful to identify which data collection tasks have been completed. For example, if a data collector needs to interview 10 specific people and the :th:`instance_name` for each filled form identifies the respondent, they can go to :guilabel:`View Sent Form` to verify which subset of interviews they have already completed. A sent form's :th:`instance_name` is maintained after it is deleted. This makes it possible to confirm what work has been completed even if submissions are configured to :ref:`delete after send <delete-after-send>`. However, it does mean sensitive data should be avoided in :th:`instance_name`.
+
+The :th:`instance_name` is also used to identify filled forms in Collect's :doc:`filled form map <collect-form-map>`.

--- a/src/xlsform.rst
+++ b/src/xlsform.rst
@@ -10,9 +10,13 @@ XLSForm
 
 .. _xlsform-introduction:
 
-:dfn:`XLSForm` is a standard for building forms in Excel. XLSForms are simple to get started with and can represent complex forms. They can be created and edited by any application that works with ``.xlsx`` documents. This means that they are portable and can leverage many useful features commonly available in spreadsheet applications such as formulas, comments and document versioning. Many users choose to use an online application such as Google Sheets or Excel for the web so that they can collaborate on or publicly share their forms.
+:dfn:`XLSForm` is a standard for building forms in Excel. XLSForms are simple to get started with and can represent complex forms. 
 
-One way to get started is by downloading or making a copy of `this template <https://docs.google.com/spreadsheets/d/1v9Bumt3R0vCOGEKQI6ExUf2-8T72-XXp_CbKKTACuko>`_. You can hover over columns to see guidance about how to use them. `The All Widgets form definition <https://docs.google.com/spreadsheets/d/1af_Sl8A_L8_EULbhRLHVl8OclCfco09Hq2tqb9CslwQ>`_ shows examples of all of the different user-visible question types.
+XLSForms can be created and edited by any application that works with ``.xlsx`` documents. This means that they are portable and can leverage many useful features commonly available in spreadsheet applications such as formulas, comments and document versioning. 
+
+Many users choose to use Google Sheets or Excel for the web so that they can collaborate on or publicly share their forms.
+
+One way to get started is by downloading or making a copy of `this form definition template <https://docs.google.com/spreadsheets/d/1v9Bumt3R0vCOGEKQI6ExUf2-8T72-XXp_CbKKTACuko>`_. You can hover over columns to see guidance about how to use them. The `All Widgets form definition <https://docs.google.com/spreadsheets/d/1af_Sl8A_L8_EULbhRLHVl8OclCfco09Hq2tqb9CslwQ>`_ shows examples of all of the different user-visible question types.
 
 The ODK documentation shows all form design examples as XLSForms and describes how XLSForms are used by ODK tools. There is also a general tutorial for building XLSForms on the `XLSForm website <http://xlsform.org/>`_.
 
@@ -32,8 +36,8 @@ The survey sheet
 At minimum, an XLSForm has a sheet named **survey** to describe the types and order of fields in a form. It must have these three columns:
 
 - :th:`type`: the type of the field represented by each row. Supported types and how they are displayed are described :doc:`here <form-question-types>`.
-- :th:`name`: the name of the field represented by each row. This name will be used in your data results. It may not contain spaces and must start with a letter or underscore. You should use a short, descriptive name and can use underscores to separate words. For example: ``date_of_birth``.
-- :th:`label`: the user-visible question text for the field represented by each row. For example: ``When was ${first_name} born?`` This text can optionally :ref:`reference other fields <variables>` or :doc:`have translations <form-language>`.
+- :th:`name`: the name of the field represented by each row. This name will be used in your data results. It may not contain spaces and must start with a letter or underscore. Use a short and descriptive name. For example: ``date_of_birth``.
+- :th:`label`: the user-visible question text for the field represented by each row. For example: ``When was ${first_name} born?`` This text can :ref:`reference other fields <variables>` or :doc:`have translations <form-language>`.
 
 The survey sheet can have many other columns to represent different :doc:`question types <form-question-types>` and :doc:`form logic <form-logic>`. You can see the most commonly-used columns in `this template <https://docs.google.com/spreadsheets/d/1v9Bumt3R0vCOGEKQI6ExUf2-8T72-XXp_CbKKTACuko>`_.
 
@@ -42,11 +46,11 @@ The survey sheet can have many other columns to represent different :doc:`questi
 The settings sheet
 --------------------
 
-You should also include a **settings** sheet to uniquely identify your form definition and its current version. The entire sheet is optional but we recommend specifying at least the following columns:
+You should also include a **settings** sheet to uniquely identify your form definition and its current version. We recommend specifying at least the following columns:
 
 - :th:`form_title`: The title that will be displayed by tools that list this form.
-- :th:`form_id`: The unique ID that identifies this form to tools that use it. It may not contain spaces and must start with a letter or underscore. You should use a short, descriptive name and can use underscores to separate words. For example: ``bench_inventory_2021``.
-- :th:`version`: The unique version code that identifies the current state of the form. A common convention is to use a format like yyyymmddrr. For example, 2017021501 is the 1st revision from Feb 15th, 2017.
+- :th:`form_id`: The unique ID that identifies this form to tools that use it. It may not contain spaces and must start with a letter or underscore. Use a short and descriptive name. For example: ``bench_inventory_2021``.
+- :th:`version`: The unique version code that identifies the current state of the form. A common convention is to use a format like yyyymmddrr. For example, ``2017021501`` is the 1st revision from Feb 15th, 2017.
 - :th:`instance_name`: An :ref:`expression <expressions>` that will be used to represent a specific filled form created from this form definition. For example, ``concat(${first_name}, ${age})``. :ref:`Learn more <instance-name>`.
 
 The **settings** sheet is also useful when using :ref:`multi-language forms <switching-languages>` or when defining a form with :ref:`encryption <defining-encrypted-form>`.
@@ -71,6 +75,22 @@ Each filled form is identified by its :th:`instance_name` value in :doc:`Collect
 
 In workflows where forms have to be be filled in multiple different steps, a useful :th:`instance_name` expression will make it much easier to find which filled form to edit. If forms only have to be edited under certain conditions (e.g. not all household members were available), you can include this status in the :th:`instance_name`.
 
-In the :guilabel:`View Sent Form` list, :th:`instance_name` can be helpful to identify which data collection tasks have been completed. For example, if a data collector needs to interview 10 specific people and the :th:`instance_name` for each filled form identifies the respondent, they can go to :guilabel:`View Sent Form` to verify which subset of interviews they have already completed. A sent form's :th:`instance_name` is maintained after it is deleted. This makes it possible to confirm what work has been completed even if submissions are configured to :ref:`delete after send <delete-after-send>`. However, it does mean sensitive data should be avoided in :th:`instance_name`.
+In the :guilabel:`View Sent Form` list, :th:`instance_name` can be helpful to identify which data collection tasks have been completed. For example, if a data collector needs to interview 25 specific people and the :th:`instance_name` for each filled form identifies the respondent, they can go to :guilabel:`View Sent Form` to verify which subset of interviews they have already completed. 
+
+A sent form's :th:`instance_name` is maintained after it is deleted. This makes it possible to confirm what work has been completed even if submissions are configured to :ref:`delete after send <delete-after-send>`. However, it does mean sensitive data should be avoided in :th:`instance_name`.
 
 The :th:`instance_name` is also used to identify filled forms in Collect's :doc:`filled form map <collect-form-map>`.
+
+
+.. _choices-sheet:
+
+The choices sheet
+--------------------
+
+If you have :ref:`multiple choice questions <select-widgets>`, you will also need a **choices** sheet to specify choices for those questions. It must have these three columns:
+
+- :th:`list_name`: The unique ID that identifies a group of choices. It may not contain spaces and must start with a letter or underscore. Use a short and descriptive name. For example: ``yes_no_maybe``.
+- :th:`name`: the name of the field represented by each row. This name will be used in your data results. It may not contain spaces and must start with a letter or underscore. For example you might use ``1`` or ``y`` for Yes and ``-1`` or ``n`` for No.
+- :th:`label`: the user-visible text for the choice represented by each row. For example: ``Yes``, ``No``, and ``Maybe``. This text can :ref:`reference other fields <variables>` or :doc:`have translations <form-language>`.
+
+Choices with the same list name are considered part of a related set of choices and will appear together for a question. This also allows a set of choices to be reused for multiple questions (for example, yes/no questions).

--- a/src/xlsform.rst
+++ b/src/xlsform.rst
@@ -47,6 +47,8 @@ You should also include a **settings** sheet to uniquely identify your form defi
 - :th:`version`: The unique version code that identifies the current state of the form. A common convention is to use a format like yyyymmddrr. For example, 2017021501 is the 1st revision from Feb 15th, 2017.
 - :th:`instance_name`: An :ref:`expression <expressions>` that will be used to represent a specific filled form created from this form definition. For example, ``concat(${first_name}, ${age})``. :ref:`Learn more <instance-name>`.
 
+The **settings** sheet is also useful when using :ref:`multi-language forms <switching-languages>` or when defining a form with :ref:`encryption <defining-encrypted-form>`.
+
 .. _instance-name:
 
 Naming filled forms


### PR DESCRIPTION
Closes #1261 

The high-level goal of this PR is to document the `settings` worksheet in XLSForm. The immediate need this satisfies is to have something useful to link to from [Central submission details page docs](https://github.com/getodk/docs/pull/1346#discussion_r625222771).

I also took the opportunity to take care of various things we've been wanting to do for some time:
- I linked to an XLSForm template. I'm pretty confident in the columns I included but if it seems controversial, we could pull it for now and have some more discussion. I don't think we want to change the column order once we publish.
- Cut out a bunch of things from the encryption page. It needs to be written but this is a quick move towards that.
- Add a high-level introduction to forms that is aimed at project designers, not developers.