### PR TITLE
Fixing audio recording example table

### DIFF
--- a/src/form-question-types.rst
+++ b/src/form-question-types.rst
@@ -1809,8 +1809,8 @@ If it's a possibility that an individual question could need different qualities
 
   select_one, yes_no, is_quiet, Are you currently in a quiet location with only one person speaking at a time?
 
-  audio recording_voice_only, Please record, quality='voice-only',, ${is_quiet} = 'yes'
-  audio recording_normal, Please record, quality='normal',, ${is_quiet} = 'no'
+  audio, recording_voice_only, Please record, quality='voice-only', ${is_quiet} = 'yes'
+  audio, recording_normal, Please record, quality='normal', ${is_quiet} = 'no'
 
 .. csv-table:: choices
   :header: list_name, name, label


### PR DESCRIPTION

<!-- ALL PRs MUST BE RELATED TO AN OPEN ISSUE -->
closes #1354 

#### What is included in this PR?

Fixed typos in the markdown example table for internal audio questions which merged the question type and name columns and put the parameters into the label column.
