### PR TITLE
Update Collect setup for projects release

### DIFF
--- a/src/collect-adb.rst
+++ b/src/collect-adb.rst
@@ -3,8 +3,8 @@
   logcat
   bugreport
   screencap
-  
-	
+
+
 Using Android Debug Bridge with Collect
 ===========================================
 
@@ -29,7 +29,7 @@ Installing and setting up ADB
 Android Studio
 ~~~~~~~~~~~~~~~~~
 
-The easiest and most well-supported way to install ADB is to 
+The easiest and most well-supported way to install ADB is to
 install `Android Studio`_,
 which includes ADB.
 After installing, you'll need to
@@ -67,7 +67,7 @@ Loading blank forms
 
 .. note::
 
-  The target path on the phone 
+  The target path on the phone
   (the last part of the command)
   must include the file name.
 
@@ -91,25 +91,25 @@ To download all filled records from a device:
 
   $ adb pull <collect-directory>/instances/*
 
-  
+
 .. _adb-dev-tasks:
-  
+
 Developer tasks and troubleshooting with ADB
 -----------------------------------------------
-  
+
 .. _downloading-database-with-adb:
 
 Downloading Collect databases
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Collect stores form definition and form record state information
-in a few SQLite databases, 
+in a few SQLite databases,
 which you can pull onto your local computer.
 
 .. code-block:: console
-  
+
   $  adb pull <collect-directory>/metadata/*.db
-  
+
 .. _saving-screenshot-with-adb:
 
 Taking screenshots
@@ -128,7 +128,7 @@ To pull the saved image locally:
 .. note::
 
   ODK Docs contributors can use the :ref:`screenshot utility script <screenshots>`, which wraps the :command:`adb` commands and assists with saving the images to the correct location and inserting appropriate markup in the documentation source.
-  
+
 .. _recording-video-with-adb:
 
 Recording video
@@ -149,7 +149,7 @@ To pull the video locally:
   $ adb pull /sdcard/video-name.png
 
 .. _adb-debug-logs:
-  
+
 Capturing logs for debugging
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -167,14 +167,14 @@ use :command:`adb logcat` to capture log events during the crash.
    .. code-block:: console
 
      adb logcat > logfile.txt
-  
+
    This will write all logged errors to your local file :file:`logfile.txt` as they occur.
 
 #. Reproduce the bug or crash event.
 
 #. Type :kbd:`CTRL-C` to stop logging.
 
-You can then upload the :file:`logfile.txt` file to 
+You can then upload the :file:`logfile.txt` file to
 a `a support forum post <https://forum.getodk.org/c/support>`_
 or post in the |forum|.
 
@@ -183,13 +183,13 @@ or post in the |forum|.
 Pull a bug report
 """"""""""""""""""
 
-If more in-depth information is needed, 
+If more in-depth information is needed,
 you can pull a complete bug report from the device.
 
 .. code-block:: console
 
   adb bugreport
-  
+
 This copies a ZIP file locally containing all system messages,
 error logs, and diagnostic output,
 along with information about the device's
@@ -206,7 +206,6 @@ The ODK Collect directory on your device is:
 
 * :file:`/sdcard/odk` if you are running an ODK Collect version less than v1.26.0 or have a file migration banner on the main screen
 * :file:`/sdcard/Android/data/org.odk.collect.android/files` if you have ODK Collect version v1.26.0+ and don't have a file migration banner on the main screen
+* If you have Collect 2021.2 or later then each Project will have its own directory which can be found in :file:`/sdcard/Android/data/org.odk.collect.android/files/projects`. Each :doc:`Project <projects>` directory will contain a blank file with the same name as the project so you can identify it.
 
-Prior to ODK Collect v1.26.0, all Collect files were stored in the :file:`/sdcard/odk` directory. This directory was available to other applications to integrate with which can be very useful but can pose privacy risks.
-
-Starting August 2020, Google will no longer allow Android applications to read or write files directly to this folder. Instead, each application will only be able to write files to a special directory that only it has access to. You can read more about this change `on the forum <https://forum.getodk.org/t/odk-collect-v1-26-storage-migration/25268>`_.
+Prior to ODK Collect v1.26.0, all Collect files were stored in the :file:`/sdcard/odk` directory. This directory was available to other applications to integrate with which can be very useful but can pose privacy risks. Starting August 2020, Google will no longer allow Android applications to read or write files directly to this folder. Instead, each application will only be able to write files to a special directory that only it has access to. You can read more about this change `on the forum <https://forum.getodk.org/t/odk-collect-v1-26-storage-migration/25268>`_.

--- a/src/collect-adb.rst
+++ b/src/collect-adb.rst
@@ -206,6 +206,6 @@ The ODK Collect directory on your device is:
 
 * :file:`/sdcard/odk` if you are running an ODK Collect version less than v1.26.0 or have a file migration banner on the main screen
 * :file:`/sdcard/Android/data/org.odk.collect.android/files` if you have ODK Collect version v1.26.0+ and don't have a file migration banner on the main screen
-* If you have Collect 2021.2 or later then each ref:`Project <collect-projects>` will have its own directory which can be found in :file:`/sdcard/Android/data/org.odk.collect.android/files/projects`. The Project directories will contain a blank file with the same name as the Project itself so you can identify it.
+* If you have Collect 2021.2 or later then each :ref:`Project <collect-projects>` will have its own directory which can be found in :file:`/sdcard/Android/data/org.odk.collect.android/files/projects`. The Project directories will contain a blank file with the same name as the Project itself so you can identify it.
 
 Prior to ODK Collect v1.26.0, all Collect files were stored in the :file:`/sdcard/odk` directory. This directory was available to other applications to integrate with which can be very useful but can pose privacy risks. Starting August 2020, Google will no longer allow Android applications to read or write files directly to this folder. Instead, each application will only be able to write files to a special directory that only it has access to. You can read more about this change `on the forum <https://forum.getodk.org/t/odk-collect-v1-26-storage-migration/25268>`_.

--- a/src/collect-adb.rst
+++ b/src/collect-adb.rst
@@ -206,6 +206,6 @@ The ODK Collect directory on your device is:
 
 * :file:`/sdcard/odk` if you are running an ODK Collect version less than v1.26.0 or have a file migration banner on the main screen
 * :file:`/sdcard/Android/data/org.odk.collect.android/files` if you have ODK Collect version v1.26.0+ and don't have a file migration banner on the main screen
-* If you have Collect 2021.2 or later then each Project will have its own directory which can be found in :file:`/sdcard/Android/data/org.odk.collect.android/files/projects`. Each :doc:`Project <projects>` directory will contain a blank file with the same name as the project so you can identify it.
+* If you have Collect 2021.2 or later then each ref:`Project <collect-projects>` will have its own directory which can be found in :file:`/sdcard/Android/data/org.odk.collect.android/files/projects`. The Project directories will contain a blank file with the same name as the Project itself so you can identify it.
 
 Prior to ODK Collect v1.26.0, all Collect files were stored in the :file:`/sdcard/odk` directory. This directory was available to other applications to integrate with which can be very useful but can pose privacy risks. Starting August 2020, Google will no longer allow Android applications to read or write files directly to this folder. Instead, each application will only be able to write files to a special directory that only it has access to. You can read more about this change `on the forum <https://forum.getodk.org/t/odk-collect-v1-26-storage-migration/25268>`_.

--- a/src/collect-adb.rst
+++ b/src/collect-adb.rst
@@ -202,10 +202,8 @@ hardware, firmware, and operating system.
 Identifying the Collect directory on your device
 -------------------------------------------------
 
-The ODK Collect directory on your device is:
+The ODK Collect directory location on your device depends on the which version of Collect you have:
 
-* :file:`/sdcard/odk` if you are running an ODK Collect version less than v1.26.0 or have a file migration banner on the main screen
-* :file:`/sdcard/Android/data/org.odk.collect.android/files` if you have ODK Collect version v1.26.0+ and don't have a file migration banner on the main screen
-* If you have Collect 2021.2 or later then each :ref:`Project <collect-projects>` will have its own directory which can be found in :file:`/sdcard/Android/data/org.odk.collect.android/files/projects`. The Project directories will contain a blank file with the same name as the Project itself so you can identify it.
-
-Prior to ODK Collect v1.26.0, all Collect files were stored in the :file:`/sdcard/odk` directory. This directory was available to other applications to integrate with which can be very useful but can pose privacy risks. Starting August 2020, Google will no longer allow Android applications to read or write files directly to this folder. Instead, each application will only be able to write files to a special directory that only it has access to. You can read more about this change `on the forum <https://forum.getodk.org/t/odk-collect-v1-26-storage-migration/25268>`_.
+- <= v1.26.0: :file:`/sdcard/odk`. Was available to other applications to integrate, but as of August 2020, Google no longer allows globally accessible storage.
+- >= v1.26.0: :file:`/sdcard/Android/data/org.odk.collect.android/files`. Only accessible by Collect.
+- >= 2021.2: :file:`/sdcard/Android/data/org.odk.collect.android/files/projects`. Only accessible by Collect. The :ref:`Project <collect-projects>` directories will contain a blank file with the same name as the Project itself.

--- a/src/collect-connect-google.rst
+++ b/src/collect-connect-google.rst
@@ -1,43 +1,19 @@
 Connecting to a Google Drive Account
-=======================================
-    
+====================================
+
 .. warning::
-   Spreadsheets have `cell limits <https://support.google.com/drive/answer/37603>`_ (currently 5 million) above which errors will be reported.
+   Google Sheets have a `cell limit <https://support.google.com/drive/answer/37603>`_ (currently 5 million) above which errors will be reported.
 
-1. From the Action Button (:guilabel:`⋮`), select :menuselection:`General Settings`
+#. `Add the Google account <https://support.google.com/android/answer/7664951>`_ you want to use to manage forms and submissions for Collect to your device if you haven't already
+#. When you first launch Collect, tap on :guilabel:`Manually enter project details`
+#. Tap on :guilabel:`Configure` next to :guilabel:`My project uses Google Drive`
+#. Select your Google account
 
-   .. image:: /img/collect-connect/main-menu-highlight-kebab.* 
-     :alt: The Main Menu screen of the Collect app. The three-dot 'kebab' menu in the upper-right corner is circled in red. 
+Setting a Fallback Submission URL
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-   .. image:: /img/collect-connect/kebab-menu-general-settings.* 
-     :alt: The Main Menu screen of the Collect App. A modal menu has unrolled in the top-right corner, with the option *About*, *General Settings*, and *Admin Settings*. *General Settings* is circled in red.
+You can set a URL for a Sheet that submissions should be sent to if their form does not specify a submission URL:
 
-2. Select :guilabel:`Server`
-
-   .. image:: /img/collect-connect/general-settings-server.* 
-     :alt: The General Settings menu in the Collect app. The options are *Server*, *User Interface*, *Form management*, and *User and device identity*. *Server* is circled in red.
-
-3. Select :guilabel:`Type`, and set it to :menuselection:`Google Drive, Google Sheets`
-
-   .. image:: /img/collect-connect/server-settings-type-google.* 
-     :alt: The Server Settings screen in the Collect app. The first item in the menu is labeled *Type*, and this item is circled in red.
-
-   .. image:: /img/collect-connect/server-settings-type-model-google.* 
-     :alt: The Server Settings screen in the Collect App, as displayed in the previous image. There is now a modal menu labeled *Platform*, with single-select radio buttons for: *ODK Aggregate*, *Google Drive, Google Sheets*, and *Other*. *Google Drive, Google Sheets* is selected and circled in red.
-
-4. Select your :guilabel:`Google Account`. You can select any account which is already linked with your device or add a new account as well.
-
-   .. image:: /img/collect-connect/server-settings-google-account.* 
-     :alt: The Server Settings screen in the Collect app. Below the *Type* setting is a section titled *Google Sheets settings*, with items for *Google Account* and *Fallback submission URL*. *Google Account* is circled in red.
-
-   .. image:: /img/collect-connect/server-settings-google-account-modal.* 
-     :alt: The Server Settings screen as displayed in the previous image. There is now a modal labeled *Google account,* with a set of radio button (single select) options. The options are Google Accounts associated with the device, and a final option labeled 'Add account'. Below that are buttons labeled CANCEL and OK.
-
-  
-5. **Optional:** Set a :guilabel:`Fallback submission URL`
-
-   When using Collect with a Google account, form submissions will be posted to a Google Sheet specified in the form. 
-
-   You have the option to specify a :guilabel:`Fallback submisison URL`. This is the URL of a Google sheet to which form submissions will be posted if the submitted form does not specify its own URL.
-
-   If your forms will specify a submission URL, you can leave this setting empty. Otherwise, enter the URL of a Google sheet you would like to use.    
+#. Tap the :ref:`Project <collect-projects>` icon of the :ref:`Main Menu <main-menu>`
+#. Tap :guilabel:`Settings` and then :guilabel:`Server`
+#. Tap :guilabel:`Fallback submission URL`, type or paste the URL for the Sheet in and then tap :guilabel:`OK` to save

--- a/src/collect-connect-google.rst
+++ b/src/collect-connect-google.rst
@@ -14,6 +14,6 @@ Setting a Fallback Submission URL
 
 You can set a URL for a Sheet that submissions should be sent to if their form does not specify a submission URL:
 
-#. Tap the :ref:`Project <collect-projects>` icon of the :ref:`Main Menu <main-menu>`
+#. Tap the :ref:`Project <collect-projects>` icon on the :ref:`Main Menu <main-menu>`
 #. Tap :guilabel:`Settings` and then :guilabel:`Server`
 #. Tap :guilabel:`Fallback submission URL`, type or paste the URL for the Sheet in and then tap :guilabel:`OK` to save

--- a/src/collect-connect.rst
+++ b/src/collect-connect.rst
@@ -3,7 +3,7 @@ Connecting to a Server
 
 ODK Collect is used to fill forms with participants. Filled forms then need to be sent to a central location for review and analysis. Generally, organizations do this by configuring Collect to send forms to a server. For those working in environments without any internet connectivity, there are :ref:`other options <other-collect-server-options>`.
 
-We recommend using :ref:`ODK Central <central-intro>` as your server and configuring Collect by QR code. :doc:`Central <central-intro>` provides user and project management features as well as tools for viewing and exporting data. For complex data collection projects, it is usually the right choice. Organizations can choose to use their own infrastructure and have total control over their server configuration. However, setting up and maintaining a server requires technical skills.
+We recommend using :ref:`ODK Central <central-intro>` as your server and configuring Collect by QR code. :doc:`Central <central-intro>` provides user and project management features as well as tools for viewing and exporting data. The easiest way to get a Central server is by using ODK Cloud <https://getodk.org/#odk-cloud>_. If you have technical skills, you can also :doc:self-host <central-install> on your own infrastructure.
 
 If you'd just like to try out ODK Collect without setting up a server, you can use the demo server which provides some sample forms. You can set this up by tapping :guilabel:`Try a demo` at the bottom of the screen when you first launch Collect.
 

--- a/src/collect-connect.rst
+++ b/src/collect-connect.rst
@@ -5,22 +5,18 @@ ODK Collect is used to fill forms with participants. Filled forms then need to b
 
 We recommend using :ref:`ODK Central <central-intro>` as your server and configuring Collect by QR code. :doc:`Central <central-intro>` provides user and project management features as well as tools for viewing and exporting data. For complex data collection projects, it is usually the right choice. Organizations can choose to use their own infrastructure and have total control over their server configuration. However, setting up and maintaining a server requires technical skills.
 
-Simple projects can choose to send data directly to :doc:`Google Sheets <collect-connect-google>`.
+If you'd just like to try out ODK Collect without setting up a server, you can use the demo server which provides some sample forms. You can set this up by tapping :guilabel:`Try a demo` at the bottom of the screen when you first launch Collect.
 
 .. _collect-connect-qr-code:
 
 Configure server from QR code
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-#. From the Action Button (:guilabel:`⋮`), select :menuselection:`Configure via QR code`
-
-    .. image:: /img/collect-configure/quick-qr-code.*
-      :alt: Configure via QR code
-      :class: device-screen-vertical
+#. When you first launch Collect, tap on :guilabel:`Configure with QR code`
 
 #. Position the QR code in the center of the camera field, under the red line. When the camera focuses on the code, it will beep and scan the code.
 
-#. Collect will apply the settings from the code and go back to the landing screen.
+#. Collect will apply the settings from the code and move you to the :ref:`Main Menu <main-menu>`.
 
 .. seealso::
 

--- a/src/collect-connect.rst
+++ b/src/collect-connect.rst
@@ -7,6 +7,8 @@ We recommend using :ref:`ODK Central <central-intro>` as your server and configu
 
 If you'd just like to try out ODK Collect without setting up a server, you can use the demo server which provides some sample forms. You can set this up by tapping :guilabel:`Try a demo` at the bottom of the screen when you first launch Collect.
 
+If you'd like to connect Collect to more than one server (or to the same server using different users) you can :ref:`add a new Project <collect-add-project>` for each server (or user).
+
 .. _collect-connect-qr-code:
 
 Configure server from QR code

--- a/src/collect-connect.rst
+++ b/src/collect-connect.rst
@@ -27,27 +27,14 @@ Configure server from QR code
 
 .. _other-collect-server-options:
 
-Configure server from settings
+Configure server with URL
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-#. From the Action Button (:guilabel:`⋮`), select :menuselection:`General Settings`
+If you're not using a server that uses QR codes you can still connect using a URL (and username/password if required):
 
-
-   .. image:: /img/collect-connect/main-menu-highlight-kebab.*
-     :alt: The Main Menu screen of the Collect app. The three-dot 'kebab' menu in the upper-right corner is circled in red.
-
-   .. image:: /img/collect-connect/kebab-menu-general-settings.*
-     :alt: The Main Menu screen of the Collect App. A modal menu has unrolled in the top-right corner, with the option *About*, *General Settings*, and *Admin Settings*. *General Settings* is circled in red.
-
-#. Select :guilabel:`Server`
-
-   .. image:: /img/collect-connect/general-settings-server.*
-     :alt: The General Settings menu in the Collect app. The options are *Server*, *User Interface*, *Form management*, and *User and device identity*. *Server* is circled in red.
-
-#. Make sure :guilabel:`ODK` is selected under :guilabel:`Type` and then fill in the :guilabel:`URL`, :guilabel:`Username` and :guilabel:`Password` for your server:
-
-   .. image:: /img/collect-connect/server-settings-odk.*
-     :alt: The Server Settings screen in the Collect app. Below the *Type* option there are three items labeled *URL*, *Username*, and *Password*.
+#. When you first launch Collect, tap on :guilabel:`Manually enter project details`
+#. Enter the URL (and username/password if required) for you server
+#. Click :guilabel:`Add`
 
 Other options
 ~~~~~~~~~~~~~~~

--- a/src/collect-connect.rst
+++ b/src/collect-connect.rst
@@ -3,11 +3,9 @@ Connecting to a Server
 
 ODK Collect is used to fill forms with participants. Filled forms then need to be sent to a central location for review and analysis. Generally, organizations do this by configuring Collect to send forms to a server. For those working in environments without any internet connectivity, there are :ref:`other options <other-collect-server-options>`.
 
-When you first install Collect, it connects to a demo server. This allows you to try out the app by :ref:`downloading blank example forms <in-app-get-blank-forms>`, :doc:`filling them out <collect-filling-forms>`, and :ref:`uploading completed forms <uploading-forms>` back to the demo server.
-  
-Once you are done trying out Collect, you will need a plan for managing forms and data submissions. We recommend using :ref:`ODK Central <central-intro>` and configuring Collect by QR code. :doc:`Central <central-intro>` provides user and project management features as well as tools for viewing and exporting data. For complex data collection projects, it is usually the right choice. Organizations can choose to use their own infrastructure and have total control over their server configuration. However, setting up and maintaining a server requires technical skills.
+We recommend using :ref:`ODK Central <central-intro>` as your server and configuring Collect by QR code. :doc:`Central <central-intro>` provides user and project management features as well as tools for viewing and exporting data. For complex data collection projects, it is usually the right choice. Organizations can choose to use their own infrastructure and have total control over their server configuration. However, setting up and maintaining a server requires technical skills.
 
-Simple projects can choose to send data directly to Google Sheets.
+Simple projects can choose to send data directly to :doc:`Google Sheets <collect-connect-google>`.
 
 .. _collect-connect-qr-code:
 

--- a/src/collect-connect.rst
+++ b/src/collect-connect.rst
@@ -14,7 +14,7 @@ If you'd like to connect Collect to more than one server (or to the same server 
 Configure server from QR code
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-#. When you first launch Collect, tap on :guilabel:`Configure with QR code`
+#. When you first launch Collect, tap on :guilabel:`Configure with QR code`.
 
 #. Position the QR code in the center of the camera field, under the red line. When the camera focuses on the code, it will beep and scan the code.
 
@@ -29,14 +29,14 @@ Configure server from QR code
 
 .. _other-collect-server-options:
 
-Configure server with URL
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Configure server manually
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you're not using a server that uses QR codes you can still connect using a URL (and username/password if required):
 
-#. When you first launch Collect, tap on :guilabel:`Manually enter project details`
-#. Enter the URL (and username/password if required) for you server
-#. Click :guilabel:`Add`
+#. When you first launch Collect, tap on :guilabel:`Manually enter project details`.
+#. Enter the URL (and username/password if required) for you server.
+#. Click :guilabel:`Add`.
 
 Other options
 ~~~~~~~~~~~~~~~

--- a/src/collect-projects.rst
+++ b/src/collect-projects.rst
@@ -5,7 +5,7 @@ Managing Projects
 
 .. versionadded:: v2021.2
 
-Starting with Collect v2021.2, Collect can be setup with mutliple Projects. Each Project in Collect has its own set of :doc:`Forms <collect-forms>` and Settings.
+Starting with Collect v2021.2, Collect can be setup with multiple Projects. Each Project in Collect has its own set of :doc:`Forms <collect-forms>` and Settings.
 
 Each Project is identified by a name, icon and color. These are then shown in at the top of the :ref:`Main Menu <main-menu>`:
 

--- a/src/collect-projects.rst
+++ b/src/collect-projects.rst
@@ -3,6 +3,24 @@
 Managing Projects
 =================
 
+.. versionadded:: v2021.2
+
+Starting with Collect v2021.2, Collect can be setup with mutliple Projects. Each Project in Collect has its own set of :doc:`Forms <collect-forms>` and Settings.
+
+Each Project is identified by a name, icon and color. These are then shown in at the top of the :ref:`Main Menu <main-menu>`:
+
+.. image:: /img/collect-projects/main-menu-with-project.png
+  :alt: Collect's Main Menu with an example Project
+  :class: device-screen-vertical
+
+.. tip::
+
+  Some examples of scenarios where having more than one project might be useful:
+
+  - An enumerator working working on different data collection efforts across different servers
+  - Multiple enumerators using one device for the same data collection project but with different user accounts on the server
+  - Form Designers testing forms on different staging/development servers
+
 .. _collect-add-project:
 
 Adding a new Project

--- a/src/collect-projects.rst
+++ b/src/collect-projects.rst
@@ -1,0 +1,13 @@
+.. _collect-projects:
+
+Managing Projects
+=================
+
+.. _collect-add-project:
+
+Adding a new Project
+~~~~~~~~~~~~~~~~~~~~
+
+#. Tap the :ref:`Project <collect-projects>` icon on the :ref:`Main Menu <main-menu>`
+#. Tap :guilabel:`Add project`
+#. Scan a QR code or tap :guilabel:`Manually add project details` to set the server for the new project

--- a/src/collect-projects.rst
+++ b/src/collect-projects.rst
@@ -1,11 +1,17 @@
 .. _collect-projects:
 
-Managing Projects
-=================
+Managing Projects in Collect
+============================
 
 .. versionadded:: v2021.2
 
 Starting with Collect v2021.2, Collect can be setup with multiple Projects. Each Project in Collect has its own set of :doc:`Forms <collect-forms>` and Settings.
+
+Some examples of scenarios where having more than one project might be useful:
+
+- An enumerator working on different data collection efforts across different servers
+- Multiple enumerators using one device for the same data collection project but with different user accounts on the server
+- Form designers testing forms on different staging/development servers
 
 Each Project is identified by a name, icon and color. These are then shown in at the top of the :ref:`Main Menu <main-menu>`:
 
@@ -13,19 +19,11 @@ Each Project is identified by a name, icon and color. These are then shown in at
   :alt: Collect's Main Menu with an example Project
   :class: device-screen-vertical
 
-.. tip::
-
-  Some examples of scenarios where having more than one project might be useful:
-
-  - An enumerator working working on different data collection efforts across different servers
-  - Multiple enumerators using one device for the same data collection project but with different user accounts on the server
-  - Form Designers testing forms on different staging/development servers
-
 .. _collect-add-project:
 
 Adding a new Project
 ~~~~~~~~~~~~~~~~~~~~
 
-#. Tap the :ref:`Project <collect-projects>` icon on the :ref:`Main Menu <main-menu>`
+#. Tap the :ref:`Project <collect-projects>` icon on the upper right of the :ref:`Main Menu <main-menu>` screen
 #. Tap :guilabel:`Add project`
 #. Scan a QR code or tap :guilabel:`Manually add project details` to set the server for the new project

--- a/src/collect-using.rst
+++ b/src/collect-using.rst
@@ -20,6 +20,7 @@ To use ODK Collect:
 .. toctree::
   :maxdepth: 2
 
+  collect-projects
   collect-forms
   collect-filling-forms
   collect-settings

--- a/src/getting-started.rst
+++ b/src/getting-started.rst
@@ -36,18 +36,14 @@ Create a form with XLSForm and upload it to Central
 #. Create a document in your favorite spreadsheet tool (Excel, Google Sheets, etc)
 #. Design your form using :doc:`XLSForm <xlsform>` or try `a sample XLSForm <https://docs.google.com/spreadsheets/d/1af_Sl8A_L8_EULbhRLHVl8OclCfco09Hq2tqb9CslwQ/edit#gid=0>`_.
 #. :ref:`Upload the form to Central <central-forms-upload>`.
-    
+
 .. _getting-started-load-form:
 
 Load a form into Collect from Central
 ----------------------------------------------------------
 
-#. :ref:`Find or create an App User <central-users-app-overview>` in Central
-#. Open Collect on your Android device
-#. Tap :guilabel:`Configure via QR code` from the menu at the top right
-   (:menuselection:`⋮ --> Configure via QR code`)
-#. Scan the QR code from Central
-#. Go back to the app home screen and select :guilabel:`Get Blank Form`, then select your form.
+#. :ref:`Create an App User <central-users-app-overview>` in Central
+#. Open Collect on your Android device, tap :guilabel:`Configure with QR code` and scan the Client Configuration Code created for your App User
 
 .. _getting-started-fill-form:
 

--- a/src/getting-started.rst
+++ b/src/getting-started.rst
@@ -33,7 +33,7 @@ You can also :ref:`install manually <install-collect-manually>` from an APK.
 
 Create a form with XLSForm and upload it to Central
 ------------------------------------------------------
-#. Create a document in your favorite spreadsheet tool (Excel, Google Sheets, etc)
+#. Create a document in your favorite spreadsheet tool (Excel, Google Sheets, etc).
 #. Design your form using :doc:`XLSForm <xlsform>` or try `a sample XLSForm <https://docs.google.com/spreadsheets/d/1af_Sl8A_L8_EULbhRLHVl8OclCfco09Hq2tqb9CslwQ/edit#gid=0>`_.
 #. :ref:`Upload the form to Central <central-forms-upload>`.
 
@@ -42,8 +42,8 @@ Create a form with XLSForm and upload it to Central
 Load a form into Collect from Central
 ----------------------------------------------------------
 
-#. :ref:`Create an App User <central-users-app-overview>` in Central
-#. Open Collect on your Android device, tap :guilabel:`Configure with QR code` and scan the Client Configuration Code created for your App User
+#. :ref:`Create an App User <central-users-app-overview>` in Central.
+#. Open Collect on your Android device, tap :guilabel:`Configure with QR code` and scan the Client Configuration Code created for your App User.
 
 .. _getting-started-fill-form:
 

--- a/src/img/collect-projects/main-menu-with-project.png
+++ b/src/img/collect-projects/main-menu-with-project.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36274f584c1fff8eff855c00f5858ee27d65264a3e13b4af67b0ffce59ac4f6c
+size 54625


### PR DESCRIPTION
Work towards #1365

#### What is included in this PR?

Update ODK "Getting Started" and Collect's "Connecting to a Server" for Projects and add the beginning of a "Managing Projects" page. This doesn't address everything we need to update and there is still more to document on Projects themselves, but I think it's a good start and makes sure new users aren't looking at out of date setup instructions.
