### PR TITLE
Upgrade and fix Python versions for more predictable builds, move packages to userland

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,15 +3,14 @@ jobs:
   build:
     working_directory: ~/work
     docker:
-      - image: circleci/python:latest
+      - image: cimg/python:3.9
     steps:
       - checkout
       - run:
           name: Install checkout requirements
           command: |
-            curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash
+            sudo apt-get update
             sudo apt-get install git-lfs
-            git lfs install
       - run:
           name: Checkout binaries
           command: git lfs pull
@@ -19,14 +18,15 @@ jobs:
           name: Install build requirements
           command: |
             sudo apt-get install pngquant
-            sudo apt-get install python-enchant
-            sudo pip install -r requirements.txt
+            sudo apt-get install python3-pip
+            sudo apt-get install python3-enchant
+            pip3 install --user -r requirements.txt 
       - run:
           name: Style guide check
           command: |
             paths=$(git diff origin/master... --name-only)
             echo $paths
-            sudo python style-test.py $paths -r src
+            python3 style-test.py $paths -r src
       - run:
           name: Build
           command: make deploy
@@ -73,7 +73,7 @@ jobs:
   deploy:
     working_directory: ~/work
     docker:
-      - image: circleci/ruby:2.7
+      - image: cimg/ruby:2.7
     steps:
       - attach_workspace:
           at: ~/work

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ build-all: build
 
 latex: build
 	@$(SPHINXBUILD) -b latex "$(TMPDIR)" "$(BUILDDIR)"/latex $(SPHINXOPTS)
-	python util/resize.py "$(BUILDDIR)"
+	python3 util/resize.py "$(BUILDDIR)"
 
 pdf: latex
 	cd "$(BUILDDIR)"/latex && \
@@ -50,11 +50,11 @@ pdf: latex
 	mv ODK.pdf ../_downloads/ODK-Documentation.pdf
 
 style-check: build
-	python style-test.py -r $(TMPDIR)
+	python3 style-test.py -r $(TMPDIR)
 
 spell-check: build
 	sphinx-build -b spelling $(TMPDIR) $(BUILDDIR)/spelling
-	python util/check-spelling-output.py $(BUILDDIR)
+	python3 util/check-spelling-output.py $(BUILDDIR)
 
 check: style-check spell-check
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,12 +18,12 @@ MarkupSafe==1.1.1
 more-itertools==4.3.0
 olefile==0.46
 pathtools==0.1.2
-Pillow>=4.3.0
+Pillow==8.3.1
 pluggy==0.7.1
 port-for==0.3.1
 proselint==0.10.2
 py==1.10.0
-pyenchant==2.0.0
+pyenchant==3.2.1
 Pygments==2.7.4
 pytest==3.7.2
 pytz==2017.2


### PR DESCRIPTION
I can confirm that image-resizing (pillow) and spell-checking (pyenchant) both work.