### PR TITLE
Most people will be converting with Central

### DIFF
--- a/src/form-logic.rst
+++ b/src/form-logic.rst
@@ -357,7 +357,7 @@ Dynamic defaults
 
 .. warning::
   
-  Support for :ref:`dynamic defaults <dynamic-defaults>` was added in Collect v1.24.0. Form conversion requires XLSForm Online ≥ v2.0.0 or pyxform ≥ v1.0.0. Using older versions will have unpredictable results.
+  Support for :ref:`dynamic defaults <dynamic-defaults>` was added in Collect v1.24.0 and Central v1.0.0. Using older versions will have unpredictable results.
 
 If you put an expression in the :th:`default` column for a question, that expression will be evaluated once when a record is first created from a form definition. This allows you to use values from outside the form like the current date or the :ref:`server username <metadata>`. Dynamic defaults as described in this section are evaluated once on record creation. See below for using :ref:`dynamic defaults in repeats <dynamic-defaults-repeats>` or setting the :ref:`default value of one field to the value of another field in the form <defaults-from-form-data>`.
 
@@ -411,7 +411,7 @@ Dynamic defaults from form data
 
 .. warning::
   
-  Support for :ref:`dynamic defaults <dynamic-defaults>` from form data was added in Collect v1.24.0. Form conversion requires XLSForm Online ≥ v2.2.0 or pyxform ≥ v1.2.0. Using older versions will have unpredictable results.
+  Support for :ref:`dynamic defaults <dynamic-defaults>` from form data was added in Collect v1.24.0 and Central v1.1.0. Using older versions will have unpredictable results.
 
 It can be helpful to use a value filled out by the enumerator as a default for another question that the enumerator will later fill in. Dynamic defaults as described above can't be used for this because they are evaluated on form or repeat creation, before any data is filled in.
 
@@ -472,7 +472,7 @@ Triggering calculations on value change
 
 .. warning::
   
-  Support for triggering calculations on value change was added in Collect v1.24.0. Form conversion requires XLSForm Online ≥ v2.2.0 or pyxform ≥ v1.2.0. Using older versions will have unpredictable results.
+  Support for triggering calculations on value change was added in Collect v1.24.0 and Central v1.1.0. Using older versions will have unpredictable results.
 
 :ref:`Calculations <calculations>` are recomputed any time one of the values in its expression changes. For example, if your form includes the calculation `${q1} + ${q2}`, it will be recomputed any time either of the values for `${q1}` or `${q2}` changes.
 

--- a/src/form-question-types.rst
+++ b/src/form-question-types.rst
@@ -1073,7 +1073,7 @@ Randomizing choice order
 
 .. note::
 
-  Randomizing choice order support was added in Collect v1.18.2 and Aggregate v1.7.1. Form conversion requires XLSForm Online ≥ v1.2.2 or pyxform ≥ v0.11.6.
+  Randomizing choice order support was added in Collect v1.18.2 and Central v1.0.0.
 
 To reduce bias, choice order can be randomized for any of the select question types described above. To display the choices in a different order each time the question is displayed, set **randomize** to **true** in the :th:`parameters` column of the XLSForm **survey** sheet:
 
@@ -1755,7 +1755,7 @@ Customizing audio quality
 
 .. versionadded:: 1.29
 
-  `ODK Collect v1.29.0 <https://github.com/getodk/collect/releases/tag/v1.29.0>`_, `pyxform` v1.3.0, `XLSForm Online` v2.3.0
+  `ODK Collect v1.29.0 <https://github.com/getodk/collect/releases/tag/v1.29.0>`_, Central v1.1.0.
 
 The quality of audio recordings can be customized using the ``quality`` parameter. If a ``quality`` is specified, the built-in recorder is always used, regardless of Collect settings. If no ``quality`` is specified and :ref:`external app recording has been disabled <use-external-app-for-audio-recording>`, ``normal`` is used. The available quality values are:
 
@@ -2487,7 +2487,7 @@ Geolocation at survey start
   :ref:`Audit log geolocation tracking <audit-geolocation-tracking>`
 
 .. note::
-  Geolocation at survey start was added in Collect v1.23 and Aggregate v2.0.4/v1.7.4. Form conversion requires XLSForm Online ≥ v1.6.1 or pyxform ≥ v0.15.1.
+  Geolocation at survey start was added in Collect v1.23 and Central v1.0.0.
 
 The :tc:`start-geopoint` question type is used to capture a single geolocation in :ref:`geopoint format <location-widgets>` when the survey is first started. Questions of type :tc:`start-geopoint` may be given any allowable name. Although it is possible to have more than one :tc:`start-geopoint` question in a form, all will have the same value.
 
@@ -2524,7 +2524,7 @@ type
 
 .. versionadded:: 1.30
 
-  `ODK Collect v1.30.0 <https://github.com/getodk/collect/releases/tag/v1.30.0>`_, `pyxform` v1.4.0, `XLSForm Online` v2.4.0
+  `ODK Collect v1.30.0 <https://github.com/getodk/collect/releases/tag/v1.30.0>`_, Central v1.2.0
 
 .. seealso::
   :doc:`Logging enumerator behavior <form-audit-log>`, :ref:`audio questions <audio>`


### PR DESCRIPTION
Central v1.0 had pyxform v1.1.0
* https://github.com/getodk/central/blob/v1.0.0/docker-compose.yml#L61
* https://github.com/getodk/pyxform-http/blob/v1.0.0/requirements.txt#L3

Central v1.1 had pyxform v1.3.3
* https://github.com/getodk/central/blob/v1.1.0/docker-compose.yml#L62
* https://github.com/getodk/pyxform-http/blob/v1.3.3/requirements.txt#L3

Central v1.2 had pyxform v1.5.1
* https://github.com/getodk/central/blob/v1.2.0/docker-compose.yml#L56
* https://github.com/getodk/pyxform-http/blob/v1.5.1/requirements.txt#L2