### PR TITLE
or_other should not be used due no language or choice_filter support

### DIFF
--- a/src/form-question-types.rst
+++ b/src/form-question-types.rst
@@ -1121,6 +1121,10 @@ This seed can also be used to recreate the order choices were displayed in. See 
 Including "other" as a choice
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. warning::
+
+  We do not recommend using :tc:`or_other` because it does not support multiple languages or :th:`choice_filter`. Instead, add your own "other" question and use form logic to have it appear as needed.
+
 On the **survey** sheet, in the :th:`type` column,
 after the type and the list_name,
 you can add :tc:`or_other`.


### PR DESCRIPTION
or_other doesn't have [language support](https://github.com/XLSForm/pyxform/issues/218) or [choice_filter](https://github.com/XLSForm/pyxform/issues/17) support and people should know that. We should probably deprecate it at some point.