### PR TITLE
Pin python version in Dockerfile to avoid 3.10 compatibility issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.9.7
 
 WORKDIR /mnt
 


### PR DESCRIPTION
<!-- ALL PRs MUST BE RELATED TO AN OPEN ISSUE -->
closes #1418 

#### What is included in this PR?
Update to base python version in Dockerfile

#### What is left to be done in the addressed issue?
Determine whether pinned python version is appropriate
