### PR TITLE
Fix pdf links

### DIFF
--- a/src/_templates/footer.html
+++ b/src/_templates/footer.html
@@ -11,7 +11,7 @@
   {% endif %}
 
   <hr/>
-<p class="footerText"><a href="_downloads/ODK-Documentation.pdf" download>Download this documentation as a PDF.</a></p>
+<p class="footerText"><a href="https://docs.getodk.org/_downloads/ODK-Documentation.pdf" download>Download this documentation as a PDF.</a></p>
 <p class="footerText">If you still need help, you can ask support questions in the <a href="https://forum.getodk.org/">ODK Forum</a>.</p>
   <div role="contentinfo">
     <p>


### PR DESCRIPTION
<!-- ALL PRs MUST BE RELATED TO AN OPEN ISSUE -->
closes #1417

#### What is included in this PR?
I noticed that the link on the [Contributing to ODK Docs](https://docs.getodk.org/contributing/) page to Download this documentation as a PDF did not work and would yield a "Failed - No file" message in the download bar. I updated the link in the footer.html file to include the entire link an incorrect path isn't inadvertently used.

#### What is left to be done in the addressed issue?
Confirm correct link is being used and correct document is being accessed.