### PR TITLE
Add up-to-date training resources

### DIFF
--- a/src/index.rst
+++ b/src/index.rst
@@ -94,6 +94,13 @@ For a complete list of our tools, check out `ODK on GitHub <https://github.com/g
 .. toctree::
   :hidden:
   :maxdepth: 2
+  :caption: Training
+
+  training
+
+.. toctree::
+  :hidden:
+  :maxdepth: 2
   :caption: Contributing
 
   contributing

--- a/src/training.rst
+++ b/src/training.rst
@@ -1,0 +1,18 @@
+Training Resources
+==================
+
+Below are resources for learning more about ODK. Email support@getodk.org if you'd like to add a link to this list.
+
+.. warning::
+
+ ODK has frequent improvements and so the resources below quickly fall out of date. We recommend you start with the resources that are most recent and check them against ODK's authoritative and up-to-date docs.
+
+#. `XLSForm form building guide <https://xlsform.org/>`_. Great as a tutorial or reference guide. Updated Jan 2022.
+
+#. `ODK Central and ODK Collect tour <https://www.youtube.com/playlist?list=PLaCCIQf3NY970ITVzhCRwItkAvdsAwzwU>`_ (video). Shows how to upload forms to Central and download those forms to Collect. Available in English and French. Updated Feb 2021.
+
+#. `ODK overview and the project manager's experience <https://www.youtube.com/watch?v=GQRue6Ys25A&t=381s>`_ (video). Shows features that ensure only clean and approved data makes its way into analysis and reporting. Updated June 2021.
+
+#. `ODK overview and the data collector's experience <https://www.youtube.com/watch?v=rVb8voaN4Fg&t=453s>`_ (video). Shows the power and flexibility of ODK forms and the mobile app user experience. Updated Dec 2020.
+
+#. `ODK's real-time data feed <https://www.youtube.com/watch?v=DI0106lbW10>`_ (video). Shows how to use ODK's data feed to build live-updating dashboards in Power BI. Updated Oct 2020.


### PR DESCRIPTION
My initial goal is to provide information that is ODK-centric (e.g., not Aggregate or Survey123 or KoBo) and is up-to-date. I think it's important to summarize each link and provide the media type and date and so I've done that.

<img width="1186" alt="Screen Shot 2022-02-07 at 12 06 08" src="https://user-images.githubusercontent.com/32369/152863370-77e237e9-596f-4070-a1dd-0f1413c0e807.png">

I cheat a bit with xlsforms.org date, but I think I can be forgiven.

I'm very open to changing any of this.