### PR TITLE
central: documentation for version 1.4.

### DIFF
--- a/src/central-encryption.rst
+++ b/src/central-encryption.rst
@@ -86,7 +86,7 @@ The passphrase hint will be displayed whenever the passphrase is needed to decry
 
 Once you have provided a passphrase and ensured that it is correct, press :guilabel:`Next` to proceed. At this time, managed encryption will be turned on for the Project. All Forms within the Project will be updated to include encryption information, and mobile devices will have to fetch these new versions in order to submit successfully to Central.
 
-Once encrypted data has been submitted, the Download button on the Form Submissions page will no longer directly download the data. Instead, you will be asked for your encryption passphrase:
+Once encrypted data has been submitted, you will be asked for your encryption passphrase when you try to download your data:
 
    .. image:: /img/central-encryption/decrypt.png
 

--- a/src/central-forms.rst
+++ b/src/central-forms.rst
@@ -1,3 +1,9 @@
+.. spelling::
+
+  Undeleting
+  undelete
+
+
 .. _central-forms-overview:
 
 Managing Forms in Central
@@ -212,7 +218,14 @@ Each published version of the Form will be listed, along with actions to downloa
 Deleting a Form
 ---------------
 
-Do not delete a form until you are completely sure you never need a form or its submissions again. If you only want to turn the form off so that it doesn't appear to users of mobile data collection apps, we suggest using the :ref:`form lifecycle controls <central-forms-lifecycle>` explained above.
+.. tip::
+   If you only want to turn the form off so that it doesn't appear to users of mobile data collection apps, we suggest using the :ref:`form lifecycle controls <central-forms-lifecycle>` explained above.
 
-If you are certain you wish to delete a form, you can find the option on the Form Settings page: click on the :menuselection:`--> Settings` tab under the name of the form at the top of the page. On the right side of this page, you will find the :guilabel:`Delete this form` button.
+If you are certain you wish to delete a Form, you can find the option on the Form Settings page: click on the :menuselection:`--> Settings` tab under the name of the form at the top of the page. On the right side of this page, you will find the :guilabel:`Delete this form` button.
+
+   .. image:: /img/central-forms/trash.png
+
+Once a Form has been deleted, it will remain in the Trash for 30 days before being permanently deleted. You can find the Trash on the Project page, under the Forms list. Here, you can undelete a Form using the button on the right. Undeleting a Form will restore it exactly as it was when deleted.
+
+After 30 days, when a Form is permanently deleted, the data will be removed from the system completely.
 

--- a/src/central-submissions.rst
+++ b/src/central-submissions.rst
@@ -104,13 +104,27 @@ Learn more about these options below:
 Downloading submissions as CSVs
 -------------------------------
 
-To download all submission data as a :file:`.zip` of :file:`.csv` tables, click on the :guilabel:`Download all # records` button on the right side of the listing page:
+To download all submission data as :file:`.csv` tables, click on the :guilabel:`Download all # records` button on the right side of the listing page:
 
    .. image:: /img/central-submissions/download-button.png
 
 If you have any row filters applied to the submission table, those filters will be applied to your download as well. You can use this to, for example, download only submissions from a particular month, or only approved submissions.
 
-Once the :file:`.zip` completes downloading, you will find one or more files when you extract it:
+Once the download dialog opens, you'll be given some additional export options.
+
+   .. image:: /img/central-submissions/download-modal.png
+
+Some of the options may be disabled if they do not apply to your data, or if they are not available due to features that you have enabled (such as managed encryption).
+
+The first two options help make Central's data output match Briefcase's more closely. If you are migrating from Briefcase, consider using them:
+
+ - The option to split :guilabel:`select multiple` choices will create a new column in the export :file:`csv` for each unique known value in each select multiple field. These columns then indicate whether each submission checked each option.
+ - The remove group names option takes out the prefix usually added to groups in the header: so for example, :code:`meta-instanceID` would become just :code:`instanceID`.
+ - Finally, the option to include previously deleted fields will include every known previously deleted field in any version of the Form in the export, along with any data found for those fields.
+
+Click on one of the format options on the right to start the download.
+
+Once the :file:`.csv` or :file:`.zip` completes downloading, you will find one or more files when you extract it:
 
  - A root table :file:`.csv` named after your Form title.
  - Join table :file:`.csv` files representing any repeats you may have in your form, with join columns on the left of each table relating each row to its counterpart in the parent table. Each join table is named to reflect its relationship with the others. If there is only one :file:`.csv` file, then your form has no repeats.

--- a/src/central-submissions.rst
+++ b/src/central-submissions.rst
@@ -116,8 +116,6 @@ Once the download dialog opens, you'll be given some additional export options.
 
 Some of the options may be disabled if they do not apply to your data, or if they are not available due to features that you have enabled (such as managed encryption).
 
-The first two options help make Central's data output match Briefcase's more closely. If you are migrating from Briefcase, consider using them:
-
  - The option to split :guilabel:`select multiple` choices will create a new column in the export :file:`csv` for each unique known value in each select multiple field. These columns then indicate whether each submission checked each option.
  - The remove group names option takes out the prefix usually added to groups in the header: so for example, :code:`meta-instanceID` would become just :code:`instanceID`.
  - Finally, the option to include previously deleted fields will include every known previously deleted field in any version of the Form in the export, along with any data found for those fields.

--- a/src/img/central-encryption/decrypt.png
+++ b/src/img/central-encryption/decrypt.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bf8c669cea5cafddd3b11389059f54b7bbe1ddb63966a25f5647087d4f86857c
-size 48994
+oid sha256:069e1f9346f1ad7b150ae85941cc40d84c42cb8528e9c21f6d737d7f9cf3563e
+size 88040

--- a/src/img/central-forms/trash.png
+++ b/src/img/central-forms/trash.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69b75297d94b84cdbaaf3ddc139bc4863fa1c6c1614d34ed8c9141b59f99cb4f
+size 125396

--- a/src/img/central-submissions/download-modal.png
+++ b/src/img/central-submissions/download-modal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e43762a2d70423ba0a7c590bb5bdd2e860329aff9e14e467f2637cee3e2b78e4
+size 62402


### PR DESCRIPTION
Adds information about the new export options and form deletion cycle. Patches a couple old spots that referenced downloads.