### PR TITLE
Last-saved won't work with binary attachments

### DIFF
--- a/src/form-logic.rst
+++ b/src/form-logic.rst
@@ -245,6 +245,10 @@ The value is pulled from the last saved record. This is often the most recently 
 
 Questions of any type can have their defaults set based on the last saved record.
 
+.. warning::
+
+  Last-saved copies over literal answer values and not binary attachments so it won't really work well with binary questions. The filename will be copied over but the actual file won't be available to Collect.
+
 .. _form-logic-gotchas:
 
 Form logic gotchas


### PR DESCRIPTION
closes #1340 

#### What is included in this PR?
Added a warning which clarifies that last-saved won't work with binary attachments:
![warning](https://user-images.githubusercontent.com/3276264/159478995-6e899e12-b5f5-481b-bfdd-393127f4734f.png)

