### PR TITLE
Skip spellchecking on Apple Silicon because enchant requires Intel chip

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -23,6 +23,7 @@ sys.path.insert(0, os.path.abspath('.'))
 sys.path.insert(0, os.path.abspath('../'))
 import video
 import sphinx_fontawesome
+import platform
 
 # -- General configuration ------------------------------------------------
 
@@ -43,6 +44,10 @@ extensions = ['sphinx.ext.autodoc',
     'sphinxcontrib.spelling',
     'video',
     'sphinx_fontawesome']
+
+# enchant requires an Intel chip
+if "arm" in platform.processor():
+    extensions.remove('sphinxcontrib.spelling')
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
enchant requires an Intel chip (https://pyenchant.github.io/pyenchant/install.html?highlight=silicon#on-macos) and I'd rather not install the Intel version of brew just for this. I also don't love using the Docker build.

This PR skips spellcheck when on Apple Silicon.