### PR TITLE
Deprecate Briefcase

### DIFF
--- a/src/briefcase-api.rst
+++ b/src/briefcase-api.rst
@@ -1,5 +1,10 @@
+:orphan:
+
 Briefcase Aggregate API
 =========================
+
+.. warning::
+  ODK Briefcase is no longer being updated. If you're using Briefcase for CSV exports, data decryption, or automation, use :doc:`ODK Central <central-intro>` instead.
 
 .. _introduction:
 

--- a/src/briefcase-install.rst
+++ b/src/briefcase-install.rst
@@ -1,5 +1,10 @@
+:orphan:
+
 Setting Up ODK Briefcase
 ===================================
+
+.. warning::
+  ODK Briefcase is no longer being updated. If you're using Briefcase for CSV exports, data decryption, or automation, use :doc:`ODK Central <central-intro>` instead.
 
 .. admonition:: Before you begin...
 

--- a/src/briefcase-intro.rst
+++ b/src/briefcase-intro.rst
@@ -1,5 +1,10 @@
+:orphan:
+
 ODK Briefcase
 ================
+
+.. warning::
+  ODK Briefcase is no longer being updated. If you're using Briefcase for CSV exports, data decryption, or automation, use :doc:`ODK Central <central-intro>` instead.
 
 :dfn:`ODK Briefcase` is a desktop application that runs on macOS, Windows, and
 Linux. It is used for pulling, pushing, and exporting forms on ODK servers

--- a/src/briefcase-using.rst
+++ b/src/briefcase-using.rst
@@ -1,5 +1,10 @@
+:orphan:
+
 Using ODK Briefcase
 ======================
+
+.. warning::
+  ODK Briefcase is no longer being updated. If you're using Briefcase for CSV exports, data decryption, or automation, use :doc:`ODK Central <central-intro>` instead.
 
 .. _pull-forms:
 

--- a/src/index.rst
+++ b/src/index.rst
@@ -27,7 +27,6 @@ While this is the recommended workflow, it is not the only way to do things. ODK
 Additional ODK tools are:
 
 - :doc:`build-intro`, a drag-and-drop form designer. We generally recommend XLSForm for its flexibility but users only building very simple forms may prefer Build.
-- :doc:`briefcase-intro`, a desktop tool that pulls and exports data from Aggregate and Collect.
 
 The specifications and libraries that power the tools are:
 
@@ -86,15 +85,6 @@ For a complete list of our tools, check out `ODK on GitHub <https://github.com/g
 .. toctree::
   :hidden:
   :maxdepth: 2
-  :caption: Briefcase
-
-  briefcase-intro
-  briefcase-install
-  briefcase-using
-
-.. toctree::
-  :hidden:
-  :maxdepth: 2
   :caption: Training
 
   training
@@ -114,7 +104,6 @@ For a complete list of our tools, check out `ODK on GitHub <https://github.com/g
   openrosa
   javarosa
   launch-collect-from-app
-  briefcase-api
 
 .. toctree::
   :hidden:


### PR DESCRIPTION
Same thing we did with Aggregate
* Add a message to the top of all pages.
* Remove from table of contents
* Add orphan tag so build completes

All this ensures that the pages are hidden, but links work. There will still need to be some clean up of mentions of Briefcase and Aggregate.