### PR TITLE
Explicitly state that launching Collect activities using their names is not supported

### DIFF
--- a/docs/launch-collect-from-app.rst
+++ b/docs/launch-collect-from-app.rst
@@ -104,3 +104,6 @@ If the URI of a form or instance is known, it can be viewed or edited. For examp
   startActivity(intent);
  
 The same thing can be done with a specific instance.
+
+.. warning::
+  Launching Collect activities using their names is not supported because those names can change at any time.


### PR DESCRIPTION
closes #1376

#### What is included in this PR?
It adds a warning that clarifies that launching Collect activities using their names is not supported

![image](https://user-images.githubusercontent.com/3276264/178299160-f6374ef3-be72-4e15-bc7e-a373b9d4e18f.png)

