### PR TITLE
Describe that failed submission can't be edited but can be revieved

### DIFF
--- a/docs/collect-forms.rst
+++ b/docs/collect-forms.rst
@@ -141,9 +141,9 @@ This will reopen the form instance, which you are then free to edit. Form instan
 
 .. note::
 
-  - `Sent` forms will not appear in the :guilabel:`Edit Saved Forms` list.
+  - `Sent` forms (including forms that failed to send) will not appear in the :guilabel:`Edit Saved Forms` list.
 
-  - `Sent` forms, will be available for viewing in :guilabel:`View Sent Forms` list, along with the details which cannot be edited.
+  - `Sent` forms (including forms that failed to send) will be available for viewing in :guilabel:`View Sent Forms` list, along with the details which cannot be edited.
 
   - You may freely edit `Saved` and `Finalized` forms.
 


### PR DESCRIPTION
closes #1367

#### What is included in this PR?
I've updated the note in https://docs.getodk.org/collect-forms/#editing-saved-forms so that now it looks like:
![image](https://user-images.githubusercontent.com/3276264/208679585-cb03eeeb-7232-428c-b792-ca068c69458e.png)

