### PR TITLE
Add direct link to export options

### DIFF
--- a/docs/central-forms.rst
+++ b/docs/central-forms.rst
@@ -176,7 +176,7 @@ Sometimes requirements change during data collection or a form design error is d
 Once a field is defined in a published Form version, the field's Data Type cannot be changed. It's always okay to add or remove fields but if any field reuses a previously existing name, it must have the same Data Type as it did before. There is one exception to this rule: you can change any field's type to `text` because all other types can be easily converted to it.
 
 .. note::
-  If a field is removed, it will not be included in exports by default. You can ask for all fields that were ever referenced in previous Form versions when you export data. Renaming a field is the same as removing a field and then adding a new one.
+  If a field is removed, it will not be included in exports by default. You can ask for all fields that were ever referenced in previous Form versions :ref:`when you export data <central-submissions-export-options>`. Renaming a field is the same as removing a field and then adding a new one.
 
   You can also put a relevance of `false()` on the field so that it's still included by default in data exports but no longer shown to data collectors.
 

--- a/docs/central-submissions.rst
+++ b/docs/central-submissions.rst
@@ -99,6 +99,11 @@ To download all submission data as :file:`.csv` tables, click on the :guilabel:`
 
 If you have any row filters applied to the submission table, those filters will be applied to your download as well. You can use this to, for example, download only submissions from a particular month, or only approved submissions.
 
+.. _central-submissions-export-options:
+
+Export options
+~~~~~~~~~~~~~~~~
+
 Once the download dialog opens, you'll be given some additional export options.
 
    .. image:: /img/central-submissions/download-modal.png
@@ -107,7 +112,7 @@ Some of the options may be disabled if they do not apply to your data, or if the
 
  - The option to split :guilabel:`select multiple` choices will create a new column in the export :file:`csv` for each unique known value in each select multiple field. These columns then indicate whether each submission checked each option.
  - The remove group names option takes out the prefix usually added to groups in the header: so for example, :code:`meta-instanceID` would become just :code:`instanceID`.
- - Finally, the option to include previously deleted fields will include every known previously deleted field in any version of the Form in the export, along with any data found for those fields.
+ - Finally, the option to include previously deleted fields will include every known previously deleted field in any version of the Form in the export, along with any data found for those fields. See :ref:`Updating Forms to a New Version <central-forms-updates>` for tips on updating a form without changing its fields.
 
 Click on one of the format options on the right to start the download.
 

--- a/docs/img/central-submissions/download-modal.png
+++ b/docs/img/central-submissions/download-modal.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e43762a2d70423ba0a7c590bb5bdd2e860329aff9e14e467f2637cee3e2b78e4
-size 62402
+oid sha256:1350928643505bf52e12577a7ac4b6b8fda0d842cdff098db6eb525207527883
+size 46885


### PR DESCRIPTION
Updates the section on submission exports to match new language. Adds a section header so we can directly link to export options. Crosslinks with form updates.