### PR TITLE
Remove media:: prefix for image, audio, video

### DIFF
--- a/docs/form-language.rst
+++ b/docs/form-language.rst
@@ -8,7 +8,9 @@ add columns of user-facing content with language-specific columns. All columns r
 
  - ``label``
  - ``hint``
- - ``media::*``
+ - ``image``
+ - ``audio``
+ - ``video``
  - ``constraint_message``
  - ``required_message``
 
@@ -17,7 +19,7 @@ followed by the `two letter language code <http://www.iana.org/assignments/langu
 
 - ``label::English (en)``
 - ``hint::French (fr)``
-- ``media::image::Español (es)``
+- ``image::Español (es)``
 
 .. note::
 
@@ -80,7 +82,7 @@ followed by the `two letter language code <http://www.iana.org/assignments/langu
 
   To avoid this, all columns that can be made multi-lingual need to be created
   as such for a multi-language form. For example, even if using the same image
-  for a question prompt you will need a ``media::image::*`` column for each
+  for a question prompt you will need a ``image::*`` column for each
   language. However, you may provide the same media filename for each.
 
   Blank cells in a language-specific column
@@ -90,7 +92,7 @@ followed by the `two letter language code <http://www.iana.org/assignments/langu
 .. rubric:: XLSForm --- Multiple languages with media example
 
 .. csv-table:: survey
-  :header: type, name, label::English (en), label::Español (es), media::image::Español (es), media::image::English (en)
+  :header: type, name, label::English (en), label::Español (es), image::Español (es), image::English (en)
 
   text, coffee, Do you want coffee?, ¿Quieres café?, mug_es.jpg, mug_en.jpg
 

--- a/docs/form-question-types.rst
+++ b/docs/form-question-types.rst
@@ -669,7 +669,7 @@ Multi select questions allow selecting multiple answers. The response for the qu
   select_multiple opt_abcd,select_multi_widget,Multi select widget,"select_multiple type with no appearance, 4 text choices"
 
 .. csv-table:: choices
-  :header: list_name, name, label, media::image
+  :header: list_name, name, label, image
 
   opt_abcd,a,A
   opt_abcd,b,B
@@ -912,7 +912,7 @@ See :ref:`image-options` to learn more about including images in surveys.
   select_one abcd_icon,select_widget,Select one widget,columns,"select_one type with columns appearance, 4 text + image choices"
 
 .. csv-table:: choices
-  :header: list_name, name, label, media::image
+  :header: list_name, name, label, image
 
   abcd_icon,a,A,a.jpg
   abcd_icon,b,B,b.jpg
@@ -943,7 +943,7 @@ When the ``columns-n`` appearance is added, the app puts choices in n columns.
   select_one abcd_icon,select_widget,Select one widget,columns-2,"select_one type with columns-2 appearance, 4 text + image choices"
 
 .. csv-table:: choices
-  :header: list_name, name, label, media::image
+  :header: list_name, name, label, image
 
   abcd_icon,a,A,a.jpg
   abcd_icon,b,B,b.jpg
@@ -974,7 +974,7 @@ When the ``no-buttons`` appearance is added, the app displays choices without th
   select_one abcd_icon,select_widget,Select one widget,columns-pack no-buttons,"select_one type with columns-pack no-buttons appearance, 4 image choices"
 
 .. csv-table:: choices
-  :header: list_name, name, label, media::image
+  :header: list_name, name, label, image
 
   abcd_icon,a,A,a.jpg
   abcd_icon,b,B,b.jpg
@@ -1008,7 +1008,7 @@ If adding images, note that the images are referenced in the choices sheet, and 
  select_one likert,likert_widget,Likert Widget,likert,"select_one type with Likert appearance, 5 image choices (strongly_disagree.jpg, disagree.jpg, neutral.jpg, agree.jpg, strongly_agree.jpg)"
 
 .. csv-table:: choices
- :header: list_name, name, label, media::image
+ :header: list_name, name, label, image
 
  likert_widget,strongly_disagree,Strongly Disagree,strongly_disagree.jpg
  likert_widget,disagree,Disagree,disagree.jpg
@@ -1156,7 +1156,7 @@ Including media files in choices
 As with questions themselves, choices can include :ref:`media <media>` (image, video, or audio files):
 
 .. csv-table:: choices
-  :header: list_name, name, label, media::image, media::video, media::audio
+  :header: list_name, name, label, image, video, audio
 
   opt_media,a,A,a.jpg
   opt_media,b,B,,b.mp4

--- a/docs/form-styling.rst
+++ b/docs/form-styling.rst
@@ -17,8 +17,7 @@ can all be styled using
 Media
 ------
 
-You can include questions in your form that display images or that play video or
-audio files by including a ``media`` column in your `XLSForm <http://xlsform.org/#media>`_.
+Question labels may include an image, an audio file and/or a video using the ``image``, ``audio`` and/or ``video`` columns.
 Files referenced should be included :ref:`in your form's media folder <loading-form-media>`.
 
 Images
@@ -33,7 +32,7 @@ Adding an image to a question displays the image as part of the question.
 .. rubric:: XLSForm
 
 .. csv-table:: survey
-  :header: type, name, label, media::image
+  :header: type, name, label, image
 
   select_one yesnodk, coffee, Do you want coffee?, mug.jpg
 
@@ -56,7 +55,7 @@ Adding audio to a question adds a play/stop button that controls the audio clip.
 .. rubric:: XLSForm
 
 .. csv-table:: survey
-  :header: type, name, label, media::audio
+  :header: type, name, label, audio
 
   text, feel, How does this song make you feel?, amazing.mp3
 
@@ -72,7 +71,7 @@ Adding video to a question adds a button that will play the video clip full scre
 .. rubric:: XLSForm
 
 .. csv-table:: survey
-  :header: type, name, label, media::video
+  :header: type, name, label, video
 
   integer, people, How many people do you see in the video?, people.mp4
 
@@ -85,7 +84,7 @@ an ``autoplay`` column specifying either ``audio`` or ``video``.
 .. rubric:: XLSForm
 
 .. csv-table:: survey
-  :header: type, name, label, media::audio, autoplay
+  :header: type, name, label, audio, autoplay
 
   text, feel, How does this song make you feel?, amazing.mp3, audio
 


### PR DESCRIPTION
The `media::` prefix is really just a `pyxform` implementation detail. It leads to issues like https://github.com/XLSForm/pyxform/issues/601 so better to remove, especially since https://xlsform.org/en/#media doesn't use it.

I did `grep -r "media::" .` from the root and verified that no `rst` docs have it.