### PR TITLE
Fixed name of csv table

### DIFF
--- a/docs/form-question-types.rst
+++ b/docs/form-question-types.rst
@@ -2542,7 +2542,7 @@ Collects a signature from the user.
 
 .. rubric:: XLSForm
 
-.. csv-table:: table
+.. csv-table:: survey
   :header: type, name, label, appearance, hint
 
   image,signature_widget,Signature widget,signature,image type with signature appearance


### PR DESCRIPTION
#### What is included in this PR?
It's just a small fix. In all other places, the table is called `survey` or `choices` to represent the names we use in xlsx.
