### PR TITLE
Add hint for how to distribute QR codes

### DIFF
--- a/docs/central-users.rst
+++ b/docs/central-users.rst
@@ -207,7 +207,7 @@ There are two ways to access the QR Code for an App User. The first is in the se
 
 If instead of a :guilabel:`See code` link you see text that says :guilabel:`Access revoked`, that App User no longer has access to the server. Create a new App User if you need a new QR Code.
 
-Once you have found the QR Code, you will be able to use it to configure ODK Collect. Please see the section on :doc:`importing settings into Collect <collect-import-export>` to learn how to do this.
+Once you have found the QR Code, distribute it to data collectors so they can configure ODK Collect. See :doc:`settings QR codes <collect-import-export>` to learn more.
 
 .. _central-users-app-revoke:
 

--- a/docs/collect-import-export.rst
+++ b/docs/collect-import-export.rst
@@ -3,6 +3,10 @@ Settings QR codes
 
 Collect's settings can be imported and exported using QR codes. These can be provided by servers (like ODK Central) or can be used to share settings from one device to another.
 
+.. tip ::
+
+  In ODK Central, you can right-click the App User QR code, save it as an image, print it, and place it in a training room. You can also send the QR code saved as an image via email or WhatsApp and ask data collectors to import it.
+
 Scanning a QR code
 ------------------
 
@@ -11,10 +15,10 @@ Settings QR codes can be scanned when adding a new Project or can be scanned to 
 .. note::
   QR codes contain settings with non-default values. When a code is scanned in, settings not explicitly included in the code are reset to their default values.
 
-Importing settings from an image saved on your device
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Importing a QR code saved on your device
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-You can import settings from a QR code saved on your device by clicking on the :fa:`ellipsis-v` icon when scanning a QR code. Then select the :guilabel:`Import QRCode` option.
+You can import settings from a QR code saved as a image on your device by clicking on the :fa:`ellipsis-v` icon when scanning a QR code. Then select the :guilabel:`Import QR code` option.
 
 .. _sharing-settings-with-another-device:
 


### PR DESCRIPTION
I struggled with where to place this and how to phrase.

Central's App User mode links to collect-import-export so I decided to put this text there there as a tip so it's more visible. For those who are coming from central-users I used "distribute" to give them a hint to click through.

I've tried to standardize where we use "QR code" vs "image" to make the docs more consistent. I think it's important to say "as an image" so people don't try to distribute screenshots which won't work as attachments. I didn't use "as a GIF" because that feels a little more technical and Collect doesn't use that term.