### PR TITLE
Add touching the postgres14 file to install

### DIFF
--- a/docs/central-install-digital-ocean.rst
+++ b/docs/central-install-digital-ocean.rst
@@ -162,6 +162,14 @@ Getting and Setting Up Central
 
      .. image:: /img/central-install/nano.png
 
+#. Let the system know that you want the latest version of the database:
+
+   .. code-block:: console
+
+     $ touch ./files/allow-postgres14-upgrade
+
+   This is mostly useful for *upgrades* but is also currently necessary for fresh installs.
+
 #. Bundle everything together into a server. This will take a long time and generate quite a lot of text output. Don't worry if it seems to pause without saying anything for a while.
 
    .. code-block:: console


### PR DESCRIPTION
For some reason I thought we had managed not to require this for fresh installs but we didn't so it needs to be documented.