### PR TITLE
Updated 'Form metadata settings'

### DIFF
--- a/docs/collect-settings.rst
+++ b/docs/collect-settings.rst
@@ -335,11 +335,8 @@ You can edit the following:
 You cannot edit these:
 
 - Device ID
-- Subscriber ID
-- SIM serial number
-- Install ID
 
-:guilabel:`Device ID` is currently set to the device IMEI. Starting in August 2020, Google will no longer allow Android applications to read the IMEI. At that time, the Collect-generated :guilabel:`Install ID` will be used as the :guilabel:`Device ID`. Both are currently displayed to allow organizations to transition over. :guilabel:`Install ID` can be copied by long-pressing on its text.
+:guilabel:`Device ID` is currently set to the Collect-generated :guilabel:`Install ID`.
 
 .. _usage-data-setting:
 

--- a/docs/img/collect-settings/form-metadata.png
+++ b/docs/img/collect-settings/form-metadata.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:86c5ac9fa0f09b6e8a38f73c781bfd5689d8a1cea03288bffb7a388ea5ad1302
-size 23800
+oid sha256:85a896c3121a2a590bbfae771808001ce184228e84da1149d2ebeb2151d4fca9
+size 15175


### PR DESCRIPTION
#### What is included in this PR?
I've updated [Form metadata settings](http://localhost:8000/collect-settings/#form-metadata-settings) according to the current state of ODK Collect. It looks like [Metadata](http://localhost:8000/form-question-types/#metadata) does not require any changes.
