### PR TITLE
Add pull option to docker compose build

### DIFF
--- a/docs/central-upgrade.rst
+++ b/docs/central-upgrade.rst
@@ -54,15 +54,16 @@ Upgrade steps
 
   $ git submodule update -i
 
-4. **Build** from the latest code you just fetched.
+4. **Build** from the latest code you just fetched. The ``pull`` options pull updates to all Docker images.
 
 .. code-block:: console
 
-  $ docker compose build
+  $ docker compose pull
+  $ docker compose build --pull
 
 .. note::
 
-  If you run into problems with this step, try stopping Central (``docker compose stop``) and then retry ``docker compose build``.
+  If you run into problems with this step, try stopping Central (``docker compose stop``) and then retry ``docker compose build --pull``.
 
 5. **Clean up unused Docker images**
 
@@ -318,7 +319,8 @@ This is *critical infrastructure upgrade*. In particular, it upgrades the includ
    
           .. code-block:: console
    
-             $ docker compose build
+             $ docker compose pull
+             $ docker compose build --pull
    
        #. **Start the database upgrade and wait for the process to exit.** This is where the new PostgreSQL 14 database is made and data copied into it. This will take a long time if you have a lot of data and/or a slow server.
    


### PR DESCRIPTION
As of https://github.com/getodk/central/pull/428, we pin all base images to minor versions. The goal is for hosters to get patches at time of upgrade.

I considered adding `pull` for all the sections in https://docs.getodk.org/central-install-digital-ocean/#advanced-configuration-options and https://docs.getodk.org/central-troubleshooting/ The nice thing with that is there would be more opportunities to get point releases. But all of those are rare so it doesn't seem worth possibly adding a confusing setep.

<S>
My understanding is that this is what the `--pull` option for `build` does and that `docker compose pull` would not update base images. https://github.com/docker/compose/issues/2742#issuecomment-180077368
</s>