### PR TITLE
Add RTL hint

### DIFF
--- a/docs/form-language.rst
+++ b/docs/form-language.rst
@@ -18,13 +18,14 @@ Each language column adds two colons and the language name,
 followed by the `two letter language code <http://www.iana.org/assignments/language-subtag-registry/language-subtag-registry>`_ in parentheses. For example:
 
 - ``label::English (en)``
-- ``hint::French (fr)``
+- ``hint::Arabic (ar)``
 - ``image::Español (es)``
 
 .. note::
 
-  The text shown in Collect's user interface (e.g., buttons, menus, dialogs)
-  is controlled by application, not the form. See :ref:`user interface settings <interface-settings>` for how to change the interface language.
+  The text shown in Collect's user interface (e.g., buttons, menus, dialogs) is controlled by application, not the form. See :ref:`user interface settings <interface-settings>` for how to change the interface language.
+
+  If you are using a RTL language (e.g., Arabic), set both Collect's user interface language and the form language to ensure proper RTL layout.
 
 .. rubric:: XLSForm --- Single language
 


### PR DESCRIPTION
I had a user ask about how to get Arabic and English in a form. 

I said the following...

> The Arabic column in the form should be RTL and the English column should be LTR. I think Excel will automatically do the right thing if Arabic is the only text cell.
> 
> Tell your Arabic users to set the mobile device or Collect language to Arabic so the app UI is RTL. Then they should set their form language to Arabic and the form text will also be RTL.

I want to add a small hint to the docs for RTL speakers.