### PR TITLE
Document how to fetch the list of forms with only the newest version

### DIFF
--- a/docs/launch-collect-from-app.rst
+++ b/docs/launch-collect-from-app.rst
@@ -70,6 +70,13 @@ To fetch the list of forms, call:
   Uri uri = "content://org.odk.collect.android.provider.odk.forms/forms"
   getContentResolver().query(uri, null, null, null, null);
 
+If you want to fetch the list of forms but with only the newest version for each ``form_id``, call:
+
+.. code-block:: java
+ 
+  Uri uri = "content://org.odk.collect.android.provider.odk.forms/newestFormsByFormId"
+  getContentResolver().query(uri, null, null, null, null);  
+
 Similarly, for the list of instances:
 
 .. code-block:: java


### PR DESCRIPTION
closes #876

#### What is included in this PR?
We have recently merged https://github.com/getodk/docs/pull/1605 so adding info about fetching the list of forms with only the newest version was the only missing element.