### PR TITLE
Crash logging can now be disabled alongside analytics

### DIFF
--- a/docs/security-privacy.rst
+++ b/docs/security-privacy.rst
@@ -112,7 +112,7 @@ We require secure HTTPS connections to ODK Build. We gather aggregate user behav
 ODK Collect
 -----------
 
-We gather aggregate user behavior through Google Analytics and gather crash logs through Google Firebase Crashlytics. We use secure HTTPS communication to transfer this data to ODK's maintainers. Users may disable analytics in the settings of the application. Crash logging cannot be disabled.
+We gather aggregate user behavior through Google Analytics and gather crash logs through Google Firebase Crashlytics. We use secure HTTPS communication to transfer this data to ODK's maintainers. Users may disable analytics and crash logging in the settings of the application.
 
 .. _security-privacy-xlsform-online:
 


### PR DESCRIPTION
I noticed this extra sentence was no longer correct.