### PR TITLE
Fix build by fixing openapi import

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,9 +16,9 @@
 import platform
 import os
 import sys
+import openapi
 sys.path.insert(0, os.path.abspath('../extensions/'))
 import sphinx_video
-import openapi
 
 # -- Project information -----------------------------------------------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ sphinx
 sphinx-autobuild
 sphinxcontrib-spelling
 furo
+openapi
 sphinx_design
 sphinx-copybutton
 sphinxcontrib-youtube


### PR DESCRIPTION
I was running into this error when I tried to build, and when I looked at the differences between this branch and an old version of `master` I had that did build, I figured out it was coming from the change to add the openapi rendering. 

```
$ make autobuild
sphinx-autobuild -b dirhtml "docs" "docs/_build/html"
[sphinx-autobuild] > sphinx-build -b dirhtml /Users/ktuite/Desktop/code/odk/docs/docs /Users/ktuite/Desktop/code/odk/docs/docs/_build/html
Running Sphinx v5.3.0

Configuration error:
There is a syntax error in your configuration file: invalid syntax (spec_processor.py, line 270)

Command exited with exit code: 2
The server will continue serving the build folder, but the contents being served are no longer in sync with the documentation sources. Please fix the cause of the error above or press Ctrl+C to stop the server.
```

#### What is included in this PR?

`import openapi` added to `requirements.txt`
In `docs/conf.py`, import of `openapi` moved to above the line that looks for extensions directory



<!-- Answer any that apply and delete the others. -->
#### What new issues will need to be opened because of this PR?

#### What is left to be done in the addressed issue?

#### What problems did you encounter?
