### PR TITLE
add autogenerated page to ignore list for sphinx-autobuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ help:
 .PHONY: help Makefile
 
 autobuild:
-	sphinx-autobuild -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)/html"
+	sphinx-autobuild -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)/html" --re-ignore "central-api|_build"
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).


### PR DESCRIPTION
#### What is included in this PR?

This fixes infinite watch loop for sphinx-autobuild, which looks for changes in `docs` directory and custom openApi extension also add/updates files in the same directory so we want to ignore watching autogenerated pages

