### PR TITLE
Improve DKIM support

### DIFF
--- a/docs/central-install-digital-ocean.rst
+++ b/docs/central-install-digital-ocean.rst
@@ -376,7 +376,7 @@ During upgrades or exports, some versions of Central may use more memory than th
 
    .. code-block:: console
 
-     $ docker compose build service && docker compose up -d service
+     $ docker compose build service && docker compose stop service && docker compose up -d service
 
 If an upgrade was the cause of the memory error, you may revert these changes after the upgrade and build and restart the service container.
 
@@ -419,7 +419,7 @@ Central uses Let's Encrypt SSL certificates to secure all communication. To use 
 
    .. code-block:: console
 
-     $ docker compose build nginx && docker compose up -d nginx
+     $ docker compose build nginx && docker compose stop nginx && docker compose up -d nginx
 
 .. _central-install-digital-ocean-custom-mail:
 
@@ -460,7 +460,7 @@ Central comes with a mail server to send password reset emails. To use a custom 
 
    .. code-block:: console
 
-     $ docker compose build service && docker compose up -d service
+     $ docker compose build service && docker compose stop service && docker compose up -d service
 
 .. _central-install-digital-ocean-custom-db:
 
@@ -521,7 +521,7 @@ Central comes with a PostgreSQL v14.x database server to store your data. To use
 
    .. code-block:: console
 
-     $ docker compose build service && docker compose up -d service
+     $ docker compose build service && docker compose stop service && docker compose up -d service
 
 .. _central-install-digital-ocean-dkim:
 
@@ -541,10 +541,12 @@ DKIM is a protocol which is used to help verify mail server identities. Without 
 
      $ cd central
 
+   .. code-block:: console
+
      $ openssl genrsa -out files/mail/rsa.private 1024
      $ openssl rsa -in files/mail/rsa.private -out files/mail/rsa.public -pubout -outform PEM
 
-#. Ensure any changes to DKIM private key are kept private
+#. Ensure any changes to DKIM private key are kept private.
 
    .. code-block:: console
 
@@ -582,7 +584,7 @@ DKIM is a protocol which is used to help verify mail server identities. Without 
 
         10 DOMAIN-NAME-HERE
 
-#. Build, stop, and start the mail container.
+#. Build and restart the mail container.
 
    .. code-block:: console
 
@@ -614,7 +616,7 @@ Enketo is the software that Central uses to render forms in a web browser. It is
 
    .. code-block:: console
 
-     $ docker compose build && docker compose up -d
+     $ docker compose build && docker compose stop && docker compose up -d
 
 .. _central-install-digital-ocean-sentry:
 
@@ -661,7 +663,7 @@ This information is only visible to the development team and should never contai
 
    .. code-block:: console
 
-     $ docker compose build && docker compose up -d
+     $ docker compose build && docker compose stop && docker compose up -d
 
 If you wish to use your own Sentry instance to receive your own errors, take these steps:
 
@@ -687,4 +689,4 @@ If you wish to use your own Sentry instance to receive your own errors, take the
 
    .. code-block:: console
 
-     $ docker compose build && docker compose up -d
+     $ docker compose build && docker compose stop && docker compose up -d

--- a/docs/central-install-digital-ocean.rst
+++ b/docs/central-install-digital-ocean.rst
@@ -236,8 +236,7 @@ Once you do see it working, you'll want to set up your first Administrator accou
 
 .. tip::
 
-  We strongly recommend using a :ref:`custom mail server <central-install-digital-ocean-custom-mail>` to ensure password reset emails are delivered reliabily. Learn more at :ref:`troubleshooting emails <troubleshooting-emails>`.
-
+  We strongly recommend using a :ref:`custom mail server <central-install-digital-ocean-custom-mail>` to ensure password reset emails are delivered reliably. Learn more at :ref:`troubleshooting emails <troubleshooting-emails>`.
 
 .. _central-install-digital-ocean-backups:
 
@@ -535,7 +534,8 @@ DKIM is a protocol which is used to help verify mail server identities. Without 
 
 #. Ensure that your server's name in DigitalOcean `matches your full domain name <https://www.digitalocean.com/community/questions/how-do-i-setup-a-ptr-record?comment=30810>`_, and that the `hostname does as well <https://askubuntu.com/questions/938786/how-to-permanently-change-host-name/938791#938791>`_. If you had to make changes for this step, restart the server to ensure they take effect.
 
-#. Generate a public and private key.
+
+#. Generate a public and private key (if one doesn't already exist).
 
    .. code-block:: console
 
@@ -543,10 +543,10 @@ DKIM is a protocol which is used to help verify mail server identities. Without 
 
    .. code-block:: console
 
-     $ openssl genrsa -out files/mail/rsa.private 1024
+     $ ! test -s files/mail/rsa.private && openssl genrsa -out files/mail/rsa.private 1024
      $ openssl rsa -in files/mail/rsa.private -out files/mail/rsa.public -pubout -outform PEM
 
-#. Ensure any changes to DKIM private key are kept private.
+#. Ensure any changes to the DKIM private key are kept private.
 
    .. code-block:: console
 

--- a/docs/central-install-digital-ocean.rst
+++ b/docs/central-install-digital-ocean.rst
@@ -226,16 +226,18 @@ Once you do see it working, you'll want to set up your first Administrator accou
 
      $ docker compose exec service odk-cmd --email YOUREMAIL@ADDRESSHERE.com user-promote
 
-#. Log into the Central website. Go to your domain name and enter in your new credentials. Once you have one administrator account, you do not have to go through this process again for future accounts: you can log into the website with your new account, and directly create new users that way.
+   If you ever lose track of your password, you can reset it with
+
+   .. code-block:: console
+
+     $ docker compose exec service odk-cmd --email YOUREMAIL@ADDRESSHERE.com user-set-password
+
+#. Log into the Central website. Go to your domain name and enter in your new credentials. Once you have one administrator account, you do not have to go through this process again for future accounts: you can log into the website with your new account, and directly create new users.
 
 .. tip::
-  If you find that users are not receiving emails, read about :ref:`troubleshooting emails <troubleshooting-emails>`.
 
-  If you ever lose track of your password, you can reset it with
+  We strongly recommend using a :ref:`custom mail server <central-install-digital-ocean-custom-mail>` to ensure password reset emails are delivered reliabily. Learn more at :ref:`troubleshooting emails <troubleshooting-emails>`.
 
-  .. code-block:: console
-
-    $ docker compose exec service odk-cmd --email YOUREMAIL@ADDRESSHERE.com user-set-password
 
 .. _central-install-digital-ocean-backups:
 
@@ -383,7 +385,7 @@ If an upgrade was the cause of the memory error, you may revert these changes af
 Using a Custom SSL Certificate
 ------------------------------
 
-Central uses Let's Encrypt SSL certificates to secure all communication. To use your own certs:
+Central uses Let's Encrypt SSL certificates to secure all communication. To use custom certificates:
 
 #. Generate a ``fullchain.pem`` (``-out``) file which contains your certificate followed by any necessary intermediate certificate(s).
 #. Generate a ``privkey.pem`` (``-keyout``) file which contains the private key used to sign your certificate.
@@ -424,7 +426,10 @@ Central uses Let's Encrypt SSL certificates to secure all communication. To use 
 Using a Custom Mail Server
 --------------------------
 
-Central comes with an mail server to send password reset emails. To use your own mail server:
+.. tip::
+  We recommend using a dedicated email service such as `Mailjet <https://www.mailjet.com>`_ for your custom mail server. Follow the dedicated service's instructions for enabling DKIM and SPF to ensure your messages are delivered.
+
+Central comes with a mail server to send password reset emails. To use a custom mail server:
 
 #. Edit ``.env`` with your mail server host, port, and authentication details.
 
@@ -467,7 +472,7 @@ Using a Custom Database Server
 
   Using a custom database server that is not on your local network, may result in poor performance.
 
-Central comes with a PostgreSQL v14.x database server to store your data. To use your own PostgreSQL database server:
+Central comes with a PostgreSQL v14.x database server to store your data. To use a custom PostgreSQL database server:
 
 #. Connect to your database server.
 
@@ -523,10 +528,10 @@ Central comes with a PostgreSQL v14.x database server to store your data. To use
 Configuring DKIM
 ----------------
 
-.. tip::
-  Users are not receiving emails? Read :ref:`troubleshooting emails <troubleshooting-emails>` before configuring DKIM.
+.. warning::
+  Do not follow these instructions if you are using a :ref:`custom mail server <central-install-digital-ocean-custom-mail>`.
 
-DKIM is a protocol which is used to help verify mail server identities. Without it, your sent mail is likely to be flagged as spam. If you intend to use a :ref:`custom mail server <central-install-digital-ocean-custom-mail>`, these instructions will not be relevant to you.
+DKIM is a protocol which is used to help verify mail server identities. Without it, your sent mail is likely to be flagged as spam.
 
 #. Ensure that your server's name in DigitalOcean `matches your full domain name <https://www.digitalocean.com/community/questions/how-do-i-setup-a-ptr-record?comment=30810>`_, and that the `hostname does as well <https://askubuntu.com/questions/938786/how-to-permanently-change-host-name/938791#938791>`_. If you had to make changes for this step, restart the server to ensure they take effect.
 

--- a/docs/central-troubleshooting.rst
+++ b/docs/central-troubleshooting.rst
@@ -33,9 +33,11 @@ Email sounds like a simple technology but in practice there are many things that
 * You can be assigned an IP address that was previously used for sending spam and is therefore blocked by many mail recipients
 * Your domain may not be recognized by mail recipients and therefore messages from it may be discarded or marked as spam
 
-To address delivery issues, consider using a dedicated email service such as `Mailjet <https://www.mailjet.com>`_. Because Central doesn't send very many emails, using such a service will generally be a cost-effective way of ensuring email delivery. Once you have an account set up, you will need to :ref:`configure Central to use it <central-install-digital-ocean-custom-mail>`.
+To solve delivery issues, we strongly recommend using a dedicated email service such as `Mailjet <https://www.mailjet.com>`_. Central doesn't send many emails, so such a service will generally be a cost-effective way of ensuring email delivery. Once you have an account set up, you will need to :ref:`configure Central to use it <central-install-digital-ocean-custom-mail>`.
 
-If you want to directly send emails from your Central installation, the `mail-tester <https://www.mail-tester.com/>`_ service can help you identify what barriers to email delivery you might have. Create a Central account with the email address that it provides, retrieve your results, and then delete the user. Typically, the first thing you will need to do is :ref:`configure DKIM <central-install-digital-ocean-dkim>` which will provide email recipients confidence that emails were actually sent by your Central server rather than by a spammer pretending to be your server.
+If you do not want to use a dedicated email service, you can try directly sending emails from your Central installation. :ref:`Configure DKIM <central-install-digital-ocean-dkim>` to increase the likelihood of your emails being delivered.
+
+The `mail-tester <https://www.mail-tester.com/>`_ service can help you identify what barriers to email delivery you might have. Create a Central account with the email address that it provides, retrieve your results, and then retire the user. 
 
 .. _troubleshooting-form-preview-:
 

--- a/docs/central-upgrade.rst
+++ b/docs/central-upgrade.rst
@@ -60,8 +60,7 @@ Upgrade steps
 
 .. code-block:: console
 
-  $ docker compose pull
-  $ docker compose build --pull
+  $ docker compose pull && docker compose build --pull
 
 .. note::
 
@@ -84,7 +83,7 @@ You'll be asked to confirm the removal of all dangling images. Agree by typing t
 
 .. code-block:: console
 
-  $ docker compose up -d
+  $ docker compose stop && docker compose up -d
 
 .. _version-specific-instructions:
 
@@ -109,8 +108,6 @@ Upgrading to Central v2023.4
 .. tabs::
    
   .. tab:: Default mail server
-     .. warning::
-       Before starting, read the instructions at the top of this section carefully and **make sure you are actually using the default mail server**.
      .. tip:: While enabling DKIM on the default mail server will improve email delivery, we strongly recommend you use a :ref:`custom mail server <central-install-digital-ocean-custom-mail>` instead.
 
  
@@ -133,7 +130,7 @@ Upgrading to Central v2023.4
 
   .. tab:: Custom mail server
      .. warning::
-       Before starting, read the instructions at the top of this section carefully and **make sure you are actually using a custom mail server**. If you are not, you will delete the private keys used to secure the emails Central sends.
+       Before starting, read the instructions at the top of this section carefully and **make sure you are actually using a custom mail server**. If you are not, you may have to reconfigure DKIM support.
 
      #. **Delete the old DKIM folder** and its contents.
 

--- a/docs/central-upgrade.rst
+++ b/docs/central-upgrade.rst
@@ -10,6 +10,7 @@ Start by reviewing upgrade notes for all versions between your current version a
 Upgrade notes
 -------------
 
+* :ref:`Central v2023.4 <central-upgrade-2023.4>`: improve email delivery
 * :ref:`Central v2023.3 <central-upgrade-2023.3>`: clean up old database if needed
 * :ref:`Central v2023.2 <central-upgrade-2023.2>`: upgrade Docker, PostgreSQL, and move configuration to ``.env``
 * :ref:`Central v2023.1 <central-upgrade-2023.1>`: plan ahead for longer than usual downtime during upgrade
@@ -89,6 +90,64 @@ You'll be asked to confirm the removal of all dangling images. Agree by typing t
 
 Version-specific upgrade instructions
 --------------------------------------
+
+.. _central-upgrade-2023.4:
+
+Upgrading to Central v2023.4
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+#. **Determine whether the install you are upgrading is using a custom mail server** or the default one:
+
+   .. code-block:: bash
+
+     $ grep EMAIL_HOST .env
+
+   If you get nothing back or there's nothing after the ``=``, you are using the default mail server. If ``DB_HOST`` is set to any value, you are using a custom mail server.
+
+#. **Upgrade your install** according to your mail server type.
+
+.. tabs::
+   
+  .. tab:: Default email server
+     .. warning::
+       Before starting, read the instructions at the top of this section carefully and **make sure you are actually using the default email server**.
+     .. tip:: While enabling DKIM on the default email server will improve email delivery, we strongly recommend you use a :ref:`custom mail server <central-install-digital-ocean-custom-mail>` instead.
+
+ 
+     #. **Copy any existing DKIM files to a new location**.
+
+        .. code-block:: console
+
+         $ cd central
+         $ mkdir files/mail
+         $ test -f files/dkim/rsa.private && cp files/dkim/rsa.private files/mail/rsa.private 
+         $ test -f files/dkim/rsa.public && cp files/dkim/rsa.public files/mail/rsa.public
+
+     #. **Delete the old DKIM folder** and its contents.
+
+        .. code-block:: console
+
+         $ rm -r files/dkim
+
+     #. **Follow** the :ref:`standard upgrade instructions <central-upgrade-steps>`.
+
+
+  .. tab:: Custom email server
+     .. warning::
+       Before starting, read the instructions at the top of this section carefully and **make sure you are actually using a custom email server**. If you are not, you will delete the private keys used to secure the emails Central sends.
+
+     #. **Delete the old DKIM folder** and its contents.
+
+        .. code-block:: console
+
+         $ cd central
+
+        .. code-block:: console
+
+         $ rm -r files/dkim
+
+     #. **Follow** the :ref:`standard upgrade instructions <central-upgrade-steps>`.
+
 
 .. _central-upgrade-2023.3:
 

--- a/docs/central-upgrade.rst
+++ b/docs/central-upgrade.rst
@@ -116,6 +116,9 @@ Upgrading to Central v2023.4
         .. code-block:: console
 
          $ cd central
+
+        .. code-block:: console
+
          $ mkdir files/mail
          $ test -f files/dkim/rsa.private && cp files/dkim/rsa.private files/mail/rsa.private 
 
@@ -125,14 +128,15 @@ Upgrading to Central v2023.4
 
          $ rm -r files/dkim
 
-     #. **Follow** the :ref:`standard upgrade instructions <central-upgrade-steps>`.
+     #. **Follow** the :ref:`standard upgrade instructions <central-upgrade-steps>`. Be sure to return here after the upgrade.
 
+     #. **Follow** the :ref:`configure DKIM <central-install-digital-ocean-dkim>` instructions to further improve email delivery. Redo these instructions even if you have previously configured DKIM. 
 
   .. tab:: Custom mail server
-     .. warning::
-       Before starting, read the instructions at the top of this section carefully and **make sure you are actually using a custom mail server**. If you are not, you may have to reconfigure DKIM support.
 
-     #. **Delete the old DKIM folder** and its contents.
+     #. **Follow** the :ref:`standard upgrade instructions <central-upgrade-steps>`.
+
+     .. note:: After the upgrade, consider deleting the now unused DKIM folder and its contents.
 
         .. code-block:: console
 
@@ -141,9 +145,6 @@ Upgrading to Central v2023.4
         .. code-block:: console
 
          $ rm -r files/dkim
-
-     #. **Follow** the :ref:`standard upgrade instructions <central-upgrade-steps>`.
-
 
 .. _central-upgrade-2023.3:
 

--- a/docs/central-upgrade.rst
+++ b/docs/central-upgrade.rst
@@ -108,10 +108,10 @@ Upgrading to Central v2023.4
 
 .. tabs::
    
-  .. tab:: Default email server
+  .. tab:: Default mail server
      .. warning::
-       Before starting, read the instructions at the top of this section carefully and **make sure you are actually using the default email server**.
-     .. tip:: While enabling DKIM on the default email server will improve email delivery, we strongly recommend you use a :ref:`custom mail server <central-install-digital-ocean-custom-mail>` instead.
+       Before starting, read the instructions at the top of this section carefully and **make sure you are actually using the default mail server**.
+     .. tip:: While enabling DKIM on the default mail server will improve email delivery, we strongly recommend you use a :ref:`custom mail server <central-install-digital-ocean-custom-mail>` instead.
 
  
      #. **Copy any existing DKIM files to a new location**.
@@ -121,7 +121,6 @@ Upgrading to Central v2023.4
          $ cd central
          $ mkdir files/mail
          $ test -f files/dkim/rsa.private && cp files/dkim/rsa.private files/mail/rsa.private 
-         $ test -f files/dkim/rsa.public && cp files/dkim/rsa.public files/mail/rsa.public
 
      #. **Delete the old DKIM folder** and its contents.
 
@@ -132,9 +131,9 @@ Upgrading to Central v2023.4
      #. **Follow** the :ref:`standard upgrade instructions <central-upgrade-steps>`.
 
 
-  .. tab:: Custom email server
+  .. tab:: Custom mail server
      .. warning::
-       Before starting, read the instructions at the top of this section carefully and **make sure you are actually using a custom email server**. If you are not, you will delete the private keys used to secure the emails Central sends.
+       Before starting, read the instructions at the top of this section carefully and **make sure you are actually using a custom mail server**. If you are not, you will delete the private keys used to secure the emails Central sends.
 
      #. **Delete the old DKIM folder** and its contents.
 
@@ -374,9 +373,7 @@ This is *critical infrastructure upgrade*. In particular, it upgrades the includ
    
      .. tab:: Default database
        .. warning::
-         Before starting:
-   
-         * Read the instructions at the top of this section carefully and **make sure you are actually using the default database configuration**. Following these instructions with a custom database setup could result in perceived data loss.
+         Before starting, read the instructions at the top of this section carefully and **make sure you are actually using the default database configuration**. Following these instructions with a custom database setup could result in perceived data loss.
    
        #. **Get the latest infrastructure version.**
    


### PR DESCRIPTION
This key needs to read by the Debian-exim user in the mail container. 

Currently, the key is mounted as [read-only](https://github.com/getodk/central/blob/master/docker-compose.yml#L33). And it inherits whatever permissions it has on the host, but there's no easy way to chgrp the file as part of mounting. 

~~The likely best way is to do so in the entrypoint.sh of the container ([example](https://github.com/ix-ai/smtp/blob/master/entrypoint.sh#L54C8-L54C19)), but I don't want to make upstream changes. I also don't want to have some command file in the docker-compose.yml~~

I've decided to be the change, and I've patched this upstream at https://github.com/ix-ai/smtp/pull/27.
