### PR TITLE
Replaced default search with Google

### DIFF
--- a/docs/_templates/sidebar/search.html
+++ b/docs/_templates/sidebar/search.html
@@ -1,0 +1,4 @@
+<form class="sidebar-search-container" method="get" action="../google-search/" role="search">
+   <input class="sidebar-search" placeholder="Search" name="q" aria-label="Search" autocomplete="off">
+ </form>
+<div>

--- a/docs/google-search.rst
+++ b/docs/google-search.rst
@@ -1,0 +1,9 @@
+Search Results
+================
+
+.. raw:: html
+  
+  <script async src="https://cse.google.com/cse.js?cx=3762c7974c3874eb3">
+  </script>
+  <div class="gcse-searchresults-only" data-darkmode="true"></div>
+


### PR DESCRIPTION
Default search is full of issues: https://github.com/sphinx-doc/sphinx/labels/html%20search

I think Google search is our best bet.

I have created a rst page to show the results but didn't add it in `toc` so build throws `checking consistency...  getodk-docs/docs/google-search.rst: WARNING: document isn't included in any toctree`. Is there any better way? or is it ok to ignore this warning. (if we go with this route then we need to add this page to ignore list of robot.txt)

Google provides many layouts, I am using "result only", which gives us ability to use custom search box and show results in a separate page. The reason to choose this approach is that default search-box of Google doesn't match our theme, especially it contains search button that takes significant space. And I am trying to avoid hacky customization.

Alternative approach is to use "overlay" layout, which shows search result in a modal box. That way we won't need a separate search rst page.

 nb: I have created "Programmable Search Engine" under my getodk account to generate `cx`. Is that okay or another account should be used?
https://programmablesearchengine.google.com/u/4/controlpanel/all

#### What is left to be done in the addressed issue?

- Google search result doesn't respect dark/light switch - need to write css for that

![image](https://github.com/getodk/docs/assets/447837/7c04cb65-43ca-42b3-a6a0-f82ef146027f)
