### PR TITLE
remove OpenMapKit reference

### DIFF
--- a/docs/form-question-types.rst
+++ b/docs/form-question-types.rst
@@ -1615,19 +1615,6 @@ Captures a compass reading, which is stored as a decimal.
   decimal,bearing_widget,Bearing widget,bearing,decimal type with bearing appearance
 
 
-.. _openmapkit-widget:
-
-OpenMapKit widget
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-`OpenMapKit`_ allows you to add questions about
-OpenStreetMap features in a Collect-rendered form.
-
-For more details, see the `OpenMapKit`_ documentation.
-
-.. _OpenMapKit: http://www.openmapkit.org
-
-
 .. _image-widgets:
 
 Image widgets


### PR DESCRIPTION
OMK has been sunset by American Red Cross (the original project owners), the fork of the server by HOT OSM last had a release update in Nov 2019, when Google changed how Android apps store/share data it broke how ODK and OMK communicated. i think the project is dead and this reference can be removed from the ODK docs.