### PR TITLE
Reduce width of device screenshots

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -28,7 +28,7 @@
 }
 
 .device-screen-vertical {
-    width: 400px;
+    width: 365px;
 }
 
 table.schema-table-wrap {


### PR DESCRIPTION
Reducing device screenshot width to 365px from 400px means two can go side-by-side with a screen width of 1500px. Prior to this change, screenshots would always appear vertically stacked on most laptop screens.