### PR TITLE
Improve wording around finalization

### DIFF
--- a/docs/collect-filling-forms.rst
+++ b/docs/collect-filling-forms.rst
@@ -303,7 +303,7 @@ Forms end with a standard screen that displays the name of the filled form and o
 
 
 .. image:: /img/collect-filling-forms/save-and-exit.* 
-  :alt: The end of a survey in the Collect app. The headline is *You are at the end of Section 55: 212 observations.* Below that is a text field labeled *Name this form*, with the value 'Demo Survey'. Then an unchecked checkbox labeled *Mark form as finalized*. Below all that is a button labeled *Save Form and Exit*.
+  :alt: The end of a survey in the Collect app. The headline is *You are at the end of Section 55: 212 observations.* Below that is a message describing that forms can't be edited after submission. Then there is a "Save as draft" button and a "Send" button.
   :class: device-screen-vertical
 
 If you tap the :guilabel:`Save as draft` button, the form will be saved and available for more editing from the :guilabel:`Drafts` screen.

--- a/docs/collect-forms.rst
+++ b/docs/collect-forms.rst
@@ -59,7 +59,9 @@ Finalizing drafts
 
   In Collect versions prior to v2023.3, it was possible to edit finalized forms. If your workflow involves adding or removing data up until form submission time, consider configuring Collect to hide the :guilabel:`Finalize` or :guilabel:`Send` button from the form end screen (see the form entry access control section of :ref:`protected settings <admin-settings>`) and using :ref:`bulk finalization <bulk-finalizing-drafts>` instead.
 
-If your device is online and Collect is configured to automatically send submissions, you can send send a filled form immediately from the form end screen by tapping the :guilabel:`Send` button. If your device is offline or Collect is not configured to automatically send submissions, you will need to mark a draft as finalized before it can be sent. Finalized forms are available from the :guilabel:`Ready to send` screen where they can be viewed or sent. You can finalize a form from the end screen by tapping the :guilabel:`Finalize` button.
+If your device is online and Collect is configured to automatically send submissions, you can send send a filled form immediately from the form end screen by tapping the :guilabel:`Send` button.
+
+If your device is offline or Collect is not configured to automatically send submissions, you will need to finalize a draft before it can be sent. Finalized forms are available from the :guilabel:`Ready to send` screen where they can be viewed or sent. You can finalize a form from the end screen by tapping the :guilabel:`Finalize` button.
 
 .. _bulk-finalizing-drafts:
 
@@ -97,7 +99,7 @@ To use data collected with the Collect app, you will need to get the filled form
 
 If you are offline or have turned automatic submission off in settings, you will find finalized forms in the :guilabel:`Ready to send` list, displayed by the name that the :ref:`form definition specifies <settings-sheet>`. When there are forms that are ready to send, you will see a blue notification badge on the :guilabel:`Ready to send` button and its title will become bold.
 
-Uploading a filled form from within the Collect app marks that form as `sent`. `Sent` forms remain viewable from the :guilabel:`Sent` list until they are deleted.
+Uploading a filled form from within the Collect app changes that filled form's status from `finalized` to `sent`. `Sent` forms remain viewable from the :guilabel:`Sent` list until they are deleted.
 
 .. image:: /img/collect-forms/main-menu-ready-to-send.*
   :alt: The Main Menu of the Collect app. The *Ready to send* button has a red arrow pointing to it.

--- a/docs/data-collector-workflows.rst
+++ b/docs/data-collector-workflows.rst
@@ -214,5 +214,4 @@ After form entry
 ~~~~~~~~~~~~~~~~~~
 By default, form data, even after it has been submitted, stays on users’ devices and can be viewed from :guilabel:`View Sent Form` as well as the :doc:`submission map <collect-form-map>`. This can act as a reference for users or help with troubleshooting issues. If you are collecting sensitive data or wish to save device storage space, you may want to enable the :ref:`Delete after send <delete-after-send>` setting.
 
-You also have different options when users reach the end of your form. By default, forms are marked as finalized which means that they are ready for submission (manual or automatic) as soon as Collect can connect to the server. Users are also shown a checkbox to save without finalizing. You can change the default and/or hide this option. This can be useful for workflows that include a supervisor check before sending data, for example.
-
+You also have different options when users reach the end of your form. By default, data collectors can choose between saving a form as draft or immediately finalizing it for submission. You can hide either those options from from the form entry access control section of :ref:`protected settings <admin-settings>`. Forcing data collectors to always save as draft can be useful for workflows that include a supervisor check before sending, for example.

--- a/docs/img/collect-filling-forms/mark-form-as-finalized.png
+++ b/docs/img/collect-filling-forms/mark-form-as-finalized.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0d3de30d63446870f89f07388c60bd23c82001d609afa41eead3825ecac2e39e
-size 66066


### PR DESCRIPTION
@alyblenkin mentioned that "mark as finalized" doesn't make as much sense now with the Finalize/Send button. 