### PR TITLE
Add force flag for entity updates

### DIFF
--- a/docs/_static/api-spec/central.yaml
+++ b/docs/_static/api-spec/central.yaml
@@ -10258,6 +10258,13 @@ paths:
         schema:
           type: string
         example: 54a405a0-53ce-4748-9788-d23a30cc3afa
+      - name: force
+        in: query
+        description: Flag to forcefully update the Entity
+        required: false
+        schema:
+          type: boolean
+        example: true
       requestBody:
         content:
           '*/*':


### PR DESCRIPTION
Looks like the functionality was added in https://github.com/getodk/central-backend/commit/c62a7f76833c194f9a16e829d349950cc4d30bce which was released in Central v2023.3.0. It was only added to docs in Central at https://github.com/getodk/central-backend/commit/43474fd09e5e2d0b1ea4c7155078c2d1665dad18 which is not yet released.

It's not a very big deal because the error message is clear but now that we've noticed the issue we might as well fix it.

I have rendered the page.