### PR TITLE
Remove partial entities docs and refer to entities detail page

### DIFF
--- a/docs/xlsform.rst
+++ b/docs/xlsform.rst
@@ -101,5 +101,4 @@ The entities sheet
 
 :doc:`Entities <central-entities>` let you share information between forms so you can collect longitudinal data, manage cases over time, and support other complex workflows.
 
-- ``list_name``: The name of the entity list that Entities will be created in.
-- ``label``: An :ref:`expression <expressions>` used to create a label for each new Entity. For example, ``concat(${first_name}, " ", ${last_name})``.
+Review the :doc:`Entities page <central-entities>` to learn more about what Entities are and how to use them.


### PR DESCRIPTION
addresses [pyxform/#669](https://github.com/XLSForm/pyxform/pull/671)

#### What is included in this PR?

Remove partial docs about entities column and instead refer to entities detail page. This is to avoid needing to update which columns are supported, in multiple pages.

<!-- Answer any that apply and delete the others. -->
#### What new issues will need to be opened because of this PR?
None

#### What is left to be done in the addressed issue?
None

#### What problems did you encounter?
None