### PR TITLE
Add warning about parameter override for external apps

### DIFF
--- a/docs/collect-external-apps.rst
+++ b/docs/collect-external-apps.rst
@@ -134,6 +134,9 @@ The ``intent`` attribute is only used when the group has an ``appearance`` of ``
 
 The external app is launched with the parameters that are defined in the intent string plus the values of all the sub-fields that are either text, decimal, integer, or binary (filename is sent). Any other sub-field is invisible to the external app.
 
+.. warning::
+  Collect will override parameters set in ``body::intent`` if the parameter name clashes with the name of a sub-field in the group. It's best to avoid using parameter names that might be used as field names in forms using your external app.
+
 Since Collect v1.30.0, it is possible to populate binary fields (:ref:`image <image-widgets>`, :ref:`video <video>`, :ref:`audio <audio>` or :ref:`file <file-upload>`) in field lists. An app that returns one or more binary files to Collect as part of a field list must provide a `content URI <https://developer.android.com/guide/topics/providers/content-provider-basics#ContentURIs>`_ as the value for each ``extra`` that corresponds to a binary question to populate. Additionally, the external application must specify `ClipData items <https://developer.android.com/reference/android/content/ClipData.Item>`_ for each URI it returns. Your app can then grant Collect temporary permissions to the files using the `Intent.FLAG_GRANT_READ_URI_PERMISSION <https://developer.android.com/reference/android/content/Intent#FLAG_GRANT_READ_URI_PERMISSION>`_ intent flag. See :ref:`a similar code example above <external-app-design>`.
 
 Typically, an external app creator decides on the names of input and output extras and documents those. Form designers use the names of the expected input extras in the ``appearance`` of the ``field-list`` used to launch the external app (e.g. ``my_text`` in ``org.mycompany.myapp(my_text='Some text')`` above). Form designers use the names of the expected outputs from the external app to name the questions in the field list.


### PR DESCRIPTION
addresses [this discussion on the forum](https://forum.getodk.org/t/should-sub-fields-override-intent-parameters-when-launching-external-app-to-populate-multiple-fields/44109/1)


#### What is included in this PR?

Adds a warning to describe the parameter clashing problem that external app creators might run into.
