### PR TITLE
readme: add note to install enchant natively

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Please [file an issue](https://github.com/getodk/docs/issues) if you can't find 
  * Install [Python 3.10+](https://www.python.org/downloads/)
  * Install [git](https://git-scm.com/downloads)
  * Install [Git-LFS](https://git-lfs.github.com/)
+ * Install [Enchant](https://abiword.github.io/enchant/).
 
 We highly recommend you use a virtual environment like [virtualenv](https://virtualenv.pypa.io/en/stable/).
 


### PR DESCRIPTION
not sure if this is just me with a broken environment, but my os install is pretty fresh and i couldn't get docs to build without installing `libenchant` natively (`brew install enchant`).


```
sphinx-autobuild -b dirhtml "docs" "docs/_build/html" --re-ignore "central-api|_build"
[sphinx-autobuild] > sphinx-build -b dirhtml /Users/.../code/odk/docs2/docs /Users/.../code/odk/docs2/docs/_build/html
Running Sphinx v7.2.6

Exception occurred:
  File "/Users/.../code/odk/docs2/venv/lib/python3.11/site-packages/enchant/_enchant.py", line 79, in from_env_var
    assert os.path.exists(library_path), library_path + " does not exist"
AssertionError: /opt/homebrew/lib/libenchant-2.dylib does not exist
The full traceback has been saved in /var/folders/.../.../T/sphinx-err-6gssz1en.log, if you want to report the issue to the developers.
```