### PR TITLE
Add xlsx tutorial link

### DIFF
--- a/docs/xlsform-first-form.rst
+++ b/docs/xlsform-first-form.rst
@@ -29,7 +29,7 @@ Open the XLSForm template
 -------------------------
 You can use any spreadsheet software to create and update an XLSForm: Excel, Google Sheets, OpenOffice Calc, and more. Pick your favorite and open the XLSForm template:
 
-* `Google Sheet <https://docs.google.com/spreadsheets/d/1v9Bumt3R0vCOGEKQI6ExUf2-8T72-XXp_CbKKTACuko/edit#gid=1068911091>`_ (use `File > Make a copy`)
+* `Google Sheet <https://docs.google.com/spreadsheets/d/1v9Bumt3R0vCOGEKQI6ExUf2-8T72-XXp_CbKKTACuko>`_ (use `File > Make a copy`)
 * `Microsoft Excel (XLSX) file <https://github.com/getodk/xlsform-template/raw/main/ODK%20XLSForm%20Template.xlsx>`_
 
 Add a required text question

--- a/docs/xlsform.rst
+++ b/docs/xlsform.rst
@@ -13,7 +13,7 @@ Many users choose to use Google Sheets or Excel for the web so that they can col
 
 If you are more adventurous, you can skip the tutorial, make a copy of the form template below, and learn to design your form that way.
 
-* `Google Sheet <https://docs.google.com/spreadsheets/d/1v9Bumt3R0vCOGEKQI6ExUf2-8T72-XXp_CbKKTACuko/edit#gid=1068911091>`_ (use `File > Make a copy`)
+* `Google Sheet <https://docs.google.com/spreadsheets/d/1v9Bumt3R0vCOGEKQI6ExUf2-8T72-XXp_CbKKTACuko>`_ (use `File > Make a copy`)
 * `Microsoft Excel (XLSX) file <https://github.com/getodk/xlsform-template/raw/main/ODK%20XLSForm%20Template.xlsx>`_
 
 Once your form has been designed, you can :ref:`upload the XLSForm directly to your ODK Central server <central-forms-upload>`. If your ODK server does not have the latest XLSForm features or you need to temporarily preview a form in a browser, try `XLSForm Online <https://getodk.org/xlsform>`_.

--- a/docs/xlsform.rst
+++ b/docs/xlsform.rst
@@ -13,7 +13,8 @@ Many users choose to use Google Sheets or Excel for the web so that they can col
 
 If you are more adventurous, you can skip the tutorial, make a copy of the form template below, and learn to design your form that way.
 
-* `XLSForm template <https://docs.google.com/spreadsheets/d/1v9Bumt3R0vCOGEKQI6ExUf2-8T72-XXp_CbKKTACuko>`_
+* `Google Sheet <https://docs.google.com/spreadsheets/d/1v9Bumt3R0vCOGEKQI6ExUf2-8T72-XXp_CbKKTACuko/edit#gid=1068911091>`_ (use `File > Make a copy`)
+* `Microsoft Excel (XLSX) file <https://github.com/getodk/xlsform-template/raw/main/ODK%20XLSForm%20Template.xlsx>`_
 
 Once your form has been designed, you can :ref:`upload the XLSForm directly to your ODK Central server <central-forms-upload>`. If your ODK server does not have the latest XLSForm features or you need to temporarily preview a form in a browser, try `XLSForm Online <https://getodk.org/xlsform>`_.
 


### PR DESCRIPTION
The XLSX export from Google Sheet is unfortunately not very nice. Also, there are people who don't want to use Google Sheet for various reasons. I think we should always link to both.