### PR TITLE
Add note about v2023.5 to Upgrading Central

### DIFF
--- a/docs/central-upgrade.rst
+++ b/docs/central-upgrade.rst
@@ -10,6 +10,7 @@ Start by reviewing upgrade notes for all versions between your current version a
 Upgrade notes
 -------------
 
+* Central v2023.5: no upgrade notes
 * :ref:`Central v2023.4 <central-upgrade-2023.4>`: improve email delivery
 * :ref:`Central v2023.3 <central-upgrade-2023.3>`: clean up old database if needed
 * :ref:`Central v2023.2 <central-upgrade-2023.2>`: upgrade Docker, PostgreSQL, and move configuration to ``.env``


### PR DESCRIPTION
On Slack, @lognaturel wrote about v2023.5:

> We don’t have a PR yet for update instructions. I don’t think there’s anything special for this one

I took a look at the changes on the `next` branch (getodk/central#537), and that sounds right to me. I also took a look at the new database migrations, and I don't see any that should take a long time to run. Given that, I added a line here about how there are no special upgrade notes for .5. We used similar language previously for v1.0 and v1.1.