### PR TITLE
Address review feedback for form end guide

### DIFF
--- a/docs/central-entities.rst
+++ b/docs/central-entities.rst
@@ -181,7 +181,7 @@ Add a new ``entities`` sheet to your XLSForm. This is where you will specify you
 
 The Entity List name will be used by Central to uniquely identify that Entity List. If an Entity List with the name you specify already exists in Central, this Form will create Entities in that existing Entity List. If Central doesn't yet have a Entity List with the specified name, it will be created.
 
-Each Entity must have a label to identify it on Central and for use in follow-up Forms. The ``label`` field on the ``entities`` sheet is where you provide the expression to define the label for each Entity. This is very similar to the :ref:`instance name specified for a Submission <instance-name>`_. The label expression can use any field in the Form, including ones that aren't saved to Entity Properties.
+Each Entity must have a label to identify it on Central and for use in follow-up Forms. The ``label`` field on the ``entities`` sheet is where you provide the expression to define the label for each Entity. This is very similar to the :ref:`instance name specified for a Submission <instance-name>`. The label expression can use any field in the Form, including ones that aren't saved to Entity Properties.
 
 .. rubric:: XLSForm
 

--- a/docs/form-audit-log.rst
+++ b/docs/form-audit-log.rst
@@ -79,7 +79,7 @@ For the most accurate locations, set ``location-priority`` to `high-accuracy`. F
 
   Disabling location tracking will not prevent users from filling out forms, but these changes are logged as events in the log.
 
-.. _viewing-audit-logs:
+.. _form-audit-log-change-tracking:
 
 Change tracking
 ~~~~~~~~~~~~~~~
@@ -90,6 +90,8 @@ You can enable change tracking so that old answers and new answers will be added
   :header: type, name, parameters
 
   audit, audit, track-changes=true
+
+.. _form-audit-log-reason-for-changes:
 
 Reason for changes
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -106,6 +108,8 @@ You can add to ``track-changes-reasons=on-form-edit`` to prompt enumerators to e
   audit, audit, track-changes-reasons=on-form-edit
 
 This will prevent filled out forms being edited without a reason being given. If a reason is given the form will be saved normally and the audit log will include a ``change reason`` event with the reason recorded in the ``change-reason`` column.
+
+.. _form-audit-log-id:
 
 Enumerator identification
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/form-audit-log.rst
+++ b/docs/form-audit-log.rst
@@ -35,7 +35,7 @@ To enable logging for a form, add a row of ``type`` ``audit`` and ``name`` ``aud
 
 A form may contain at most one row of ``type`` ``audit``.
 
-.. _audit-geolocation-tracking:
+.. _form-audit-geolocation-tracking:
 
 Location tracking
 ~~~~~~~~~~~~~~~~~

--- a/docs/form-question-types.rst
+++ b/docs/form-question-types.rst
@@ -2658,7 +2658,7 @@ Geolocation at survey start
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. seealso::
-  :ref:`Audit log geolocation tracking <audit-geolocation-tracking>`
+  :ref:`Audit log geolocation tracking <form-audit-geolocation-tracking>`
 
 .. note::
   Geolocation at survey start was added in Collect v1.23 and Central v1.0.0.

--- a/docs/guide-end-of-form.rst
+++ b/docs/guide-end-of-form.rst
@@ -40,6 +40,7 @@ Finalized forms are ready to be sent and can't be edited. The ``finalized`` stat
 
 * give data collectors control over when filled forms are queued for submission.
 * reduce the risk that data collectors continue editing data after they no longer have access to the data collection subject.
+* prevent edits after an important workflow step is completed (for example, supervisor review)
 * let Collect do data processing with a guarantee that the data won't change (for example, creating :doc:`Entities <central-entities>`).
 
 The ``finalized`` state is only necessary because Collect allows users to save and work with data offline. If your data collectors are guaranteed to always have connectivity, you can turn on :ref:`Auto send <guide-form-states-auto-send>` so that they never need to see filled forms in the ``finalized`` state.
@@ -49,7 +50,7 @@ Sent
 
 Sent forms have been received by the server and can't be edited from Collect. The ``sent`` state exists to:
 
-* let the user see data that they submitted.
+* let the user see data that they sent.
 * enable troubleshooting and data recovery in case of issues with the server.
 
 Collect can also optionally be configured to :ref:`delete submissions after send <delete-after-send>` to reduce device storage needs or ensure greater data protection.
@@ -72,12 +73,12 @@ Auto send setting
 
 We generally recommend turning on :guilabel:`auto send` in :ref:`form management settings <form-management-settings>`. When :guilabel:`auto send` is on, Collect attempts to send filled forms as soon as they are finalized. The benefits of :guilabel:`auto send` are:
 
-* reduced risk of data collectors forgetting to submit data in a timely way.
-* automatically retry failed submissions. On poor or intermittent data connections, this can be very helpful.
+* reduced risk of data collectors forgetting to send data in a timely way.
+* more opportunities to retry sending. On poor or intermittent data connections, this can be very helpful.
 * less for data collectors to think about (and you can also :ref:`hide the Ready to send button <guide-form-states-hide-buttons>`).
-* less chance that all data collectors submit at the same time (such as the end of their work day) which could lead to network congestion or high load on the server.
+* less chance that all data collectors send at the same time (such as the end of their work day) which could lead to network congestion or high load on the server.
 
-One case where you may need to turn :guilabel:`auto send` off is if it's important for data collectors to submit while on a network connection that is higher bandwidth, more secure, or lower-cost. In some cases, changing the setting to ``WiFi only`` or ``Cellular only`` may address these needs.
+One case where you may need to turn :guilabel:`auto send` off is if it's important for data collectors to send data while on a network connection that is higher bandwidth, more secure, or lower-cost. In some cases, changing the setting to ``WiFi only`` or ``Cellular only`` may address these needs.
 
 .. _guide-form-states-hide-buttons:
 
@@ -114,25 +115,17 @@ You can also use :ref:`draft names <instance-name>` to include information about
 
 If you use a constraint as in the above example, the user will need to come back into the draft and change their answer to the question before they can send the data.
 
-If your users have many drafts and will only need to edit a few before sending them, you can use a ``note`` without a constraint to guide users to save as draft. They will then be able to use the :ref:`bulk finalization <bulk-finalizing-drafts>` functionality when they are ready to submit.
+If your users have many drafts, will only need to edit a few before sending them, but don't know which ones will need to be edited, you can use a ``note`` without a constraint to guide users to save as draft.
 
 .. tip::
 
   In general, ``note`` form fields and ``hint`` text are powerful opportunities to guide users through your intended workflow.
 
-Remove save draft (:fa:`floppy-disk`) while filling a form
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The :ref:`bulk finalization <bulk-finalizing-drafts>` functionality makes it faster to send all error-free drafts once necessary edits have been made.
 
-Collect's :ref:`protected access control settings <admin-settings>` also contain a :guilabel:`Form Entry Settings` section for hiding actions available from the form filling screen. You can hide the Save (:fa:`floppy-disk`) button from the menu and from the :ref:`form exit dialog <exit-form-filling>`. This will prevent data collectors from saving as draft during a form filling session.
-
-You may still want to allow them to save as draft from the form end screen if, for example, it's appropriate for them to make small edits after all of the initial data is captured.
-
-Remove :guilabel:`Save as draft` from the form end screen
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-You can use :ref:`protected access control settings <admin-settings>` to hide the :guilabel:`Save as draft` button from the form end screen. This can be useful when you want to guarantee that data collectors go all the way to the end of a form and can't edit a completed form. You may also want to hide the :ref:`jump menu <jumping>`.
-
-You can hide the :guilabel:`Save as draft` functionality from the form end screen and leave it in the form filling screen if you want data collectors to be able to interrupt form filling sessions in certain cases but want them to finalize as soon as all required data has been captured.
+.. image:: /img/collect-forms/drafts-action-menu.*
+  :alt: The Drafts screen. Several drafts are listed by name and the action menu is open.
+  :class: device-screen-vertical
 
 Remove :guilabel:`Finalize` / :guilabel:`Send` button from the form end screen
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -141,10 +134,35 @@ In some cases, you may want data collectors to always save as draft. This will a
 
 To eventually send, someone can either show the button, or use the :guilabel:`Finalize all drafts` functionality from the :guilabel:`Drafts` list.
 
+Remove save draft (:fa:`floppy-disk`) while filling a form
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Collect's :ref:`protected access control settings <admin-settings>` also contain a :guilabel:`Form Entry Settings` section for hiding actions available from the form filling screen. You can hide the Save (:fa:`floppy-disk`) button from the menu and from the :ref:`form exit dialog <exit-form-filling>`. This will prevent data collectors from saving as draft during a form filling session.
+
+You may still want to allow them to save as draft from the form end screen if, for example, it's appropriate for them to make small edits after all of the initial data is captured.
+
+.. _guide-form-states-hide-save-draft-form-end:
+
+Remove :guilabel:`Save as draft` from the form end screen
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can use :ref:`protected access control settings <admin-settings>` to hide the :guilabel:`Save as draft` button from the form end screen. This can be useful when you want to guarantee that data collectors go all the way to the end of a form and can't edit a completed form. You may also want to hide the :ref:`jump menu <jumping>`.
+
+You can hide the :guilabel:`Save as draft` functionality from the form end screen and leave it in the form filling screen if you want data collectors to be able to interrupt form filling sessions in certain cases but want them to finalize as soon as all required data has been captured.
+
 Remove :guilabel:`Finalize all drafts` from the :guilabel:`Drafts` list
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you want to guarantee that each draft is finalized from the form end screen, you can remove :guilabel:`Finalize all drafts` from the :ref:`protected access control settings <admin-settings>`. For example, if you want data collectors to verify each submission before finalizing it, you may not want them to bulk finalize.
+
+.. _guide-form-states-form-audit-log:
+
+Capture data collector behavior in the form audit log
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Collect's :doc:`audit logging <form-audit-log>` makes it possible to capture a record of every action that a user took while filling out a form. In particular, the log tracks exiting and entering a form and can optionally :ref:`track changes <form-audit-log-change-tracking>` and capture :ref:`reasons for changes <form-audit-log-reason-for-changes>` on draft edits. Turning on audit logging can be a powerful way to verify that a desired workflow is being followed.
+
+The amount of data captured by audit logging can appear overwhelming but it's not necessary to carefully analyze the logs to get value out of them. First, the very act of communicating to data collectors that their actions are being logged for quality assurance will make data collectors more mindful of how they interact with forms. Additionally, manually looking through the log for specific submissions during training or for submissions with unexpected data can provide valuable insights.
 
 .. _guide-form-states-admin-password:
 
@@ -160,7 +178,7 @@ In many cases, the admin password will never need to be used: its purpose is onl
 Customizations for common workflows
 ------------------------------------
 
-Some questions to ask yourself as you design your workflow are:
+Some questions to ask yourself and your data collectors as you design your workflow are:
 
 * Is it possible for a data collector to reach the end of the form but still have information to fill in?
 * What should happen if a data collector is interrupted while filling out a form?
@@ -168,15 +186,17 @@ Some questions to ask yourself as you design your workflow are:
 * How many times will data collectors repeat the same workflow?
 * How capable are data collectors of making independent decisions when faced with unexpected situations like an interview being interrupted?
 * How trusted and well-trained are data collectors? Are they likely to want to "cheat" in some way to save time and/or effort?
-* What are the consequences of incorrect data being submitted? What are the next steps if that happens and is detected?
+* Will data collectors be in a distracting or stressful environment that could reduce their usual capacities or honesty?
+* What are the consequences of incorrect data being sent? What are the next steps if that happens and is detected?
+* How much workflow support do data collectors want to be included in the form(s) they use?
 
-As you answer these questions, you will get a clearer sense of what needs to happen when data collectors need to exit a form. This section includes some common workflow patterns and how to use the tools outlined above to support them.
+As you answer these questions, you will get a clearer sense of what needs to happen when data collectors need to exit a form. This section includes some common workflow patterns and how to use the tools outlined above to support them. Many of these ideas can be combined if your workflow has aspects of more than one of these patterns.
 
 No edits allowed after leaving data collection subject
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 In many workflows, it's important to guarantee that data is not changed after the data collector no longer has access to the data collection subject. For example, a nurse administering a vaccine should generally capture all data about that vaccination encounter while their patient is with them. They should not rely on their memory to fill in details after the encounter. To guarantee that data collectors have to fill out the form in one session:
 
-* Remove :guilabel:`Save as draft` from the form end screen and :fa:`floppy-disk` from the form filling experience.
+* Remove :guilabel:`Save as draft` from the form end screen and :fa:`floppy-disk` from the form filling experience and form exit dialog.
 * Hide the :guilabel:`Drafts` button from the Main Menu.
 * (Generally) Turn on :guilabel:`Auto send`.
 * (If data is highly sensitive or devices are not trusted) Turn on :guilabel:`Delete after send`.
@@ -185,23 +205,41 @@ In many workflows, it's important to guarantee that data is not changed after th
 
 When data collectors reach the form end screen, they only have the option to :guilabel:`Finalize`. If they are interrupted during a form filling session, they need to exit and discard changes or rely on automatic data backups and recovery (the partially-filled form will open automatically when they open the same blank form again).
 
-Edits may be needed to some drafts
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-In some workflows, new information may need to be added to a form after a first data collection event. For example:
+.. note::
+  If you would still like to leave the door open to edits but they are generally strongly discouraged, you could leave the option to save as draft from the form filling experience and use :ref:`audit logging <guide-form-states-form-audit-log>` with change tracking and reasons for change to get more information on edits that are made.
 
+Edits are needed to specific, known drafts
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Saving as draft and making edits can be an expected and important part of a workflow. For example:
+
+* some specific filled forms may require adding details that were initially unavailable.
 * a form may capture data from multiple days.
-* a data collection subject may be observable at different times or from different angles, revealing new information.
-* review to fix small mistakes like typos may be encouraged.
 * tasks like transcribing an audio recording may be needed.
+
+This can generally be addressed in form design by using required questions. You can also use a ``note``, a ``hint``, or a ``required_message`` to prompt users to exit the form and :guilabel:`Save as draft` at known points of the form.
+
+If you have designed your form so that it's only possible to reach the form end screen once all necessary tasks are complete, you may want to :ref:`hide the Save as draft button from the form end screen <guide-form-states-hide-save-draft-form-end>`. It can be easier for data collectors to take the right action if they always use the back button to save as draft and only use the form end screen to finalize/send.
+
+Edits are needed but it's not known ahead of time to which drafts
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+In other workflows, edits are needed but it is not known ahead of time which drafts will be edited. For example:
+
+* a data collection subject may be observable at different times or from different angles, revealing new information.
+* self-review to fix small mistakes like typos may be encouraged.
+
+.. warning::
+  Although self-review can be a powerful way to catch mistakes, it can also lead to accidental data fabrication. If you are considering this kind of workflow in a context where the data collection subject will no longer be available, consider running an experiment to measure whether allowing later edits improves or harms data quality. You may find it useful to turn on Collect's :ref:`audit logging <guide-form-states-form-audit-log>` and specifically to configure :ref:`change tracking <form-audit-log-change-tracking>`.
 
 To support this need, you can take the :guilabel:`Finalize` / :guilabel:`Send` button off the form end screen and require that data collectors always use :ref:`bulk finalization <bulk-finalizing-drafts>`:
 
-* Remove :guilabel:`Finalize` from the end of form screen.
+* Remove :guilabel:`Finalize` from the :ref:`form end screen <completing-form>`.
 * (If data collectors may be tempted to change settings) Set an admin password.
 * (If it's important to be able to block finalization of specific filled forms) Add a required yes or no question asking whether further edits are needed with a constraint that the answer must be ``No``.
 * Train data collectors on using :ref:`bulk finalization <bulk-finalizing-drafts>`.
 
-When data collectors reach the end of form screen, they only have the option of saving as draft. They can then make edits from the :guilabel:`Drafts` list as needed. When they are ready to submit, they go to :guilabel:`Drafts` and tap on the :guilabel:`Finalize all drafts` menu item. All forms marked with ``no errors`` are finalized and sent. If there are certain submissions that they know are not yet ready, they can edit them to cause a validation error. This is most convenient to do with a yes or no question asking whether further edits are needed.
+When data collectors reach the :ref:`form end screen <completing-form>`, they only have the option of saving as draft. They can then make edits from the :guilabel:`Drafts` list as needed. 
+
+When they are ready to send multiple drafts, they go to :guilabel:`Drafts` and tap on the :guilabel:`Finalize all drafts` menu item. All forms marked with ``no errors`` are finalized and sent. If there are certain drafts that have ``no errors`` but may not yet be ready to send, data collectors can edit those drafts to cause a validation error and make sure they can't be finalized. This is most convenient to do with a yes or no question asking whether further edits are needed.
 
 Supervisor review required before submission
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -212,6 +250,7 @@ You will generally want to design the form so it enforces the review process and
 * Add a checklist of actions the supervisor needs to take with an option to check each one off.
 * Ask the reviewer to type in their name.
 * Ask the reviewer to type in a special code which they don't show to data collectors (use the :guilabel:`Delete after send` setting so data collectors can't view the code in sent forms).
+* Ask the reviewer to scan a barcode that only they have access to
 * Ask the reviewer to add their signature.
 
 .. image:: /img/guide-end-of-form/reviewer-checklist.* 
@@ -230,13 +269,13 @@ You can use :ref:`name drafts <instance-name>` to make it easy to see from the :
   :alt: The Collect app showing the draft list with some drafts marked as "ready for review" and others as "edits needed".
   :class: device-screen-vertical
 
-When a reviewer finishes reviewing a draft, they can immediately finalize it so it can be submitted.
+When a reviewer finishes reviewing a draft, they can immediately finalize it so it can be sent.
 
-Only trusted reviewers can submit
+Only trusted reviewers can send
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-If you want to guarantee that a trusted reviewer submits all forms, you can disable data collectors' access to finalize forms:
+If you want to guarantee that a trusted reviewer sends all forms, you can disable data collectors' access to finalize forms:
 
-* Remove :guilabel:`Finalize` from the end of form screen.
+* Remove :guilabel:`Finalize` from the form end screen.
 * Remove :guilabel:`Finalize all drafts` from the :guilabel:`Drafts` list.
 * Set an admin password and communicate it to trusted reviewers.
 * (Optional) Hide the :guilabel:`Ready to send` button from the main menu (forms will only be listed there if auto send is off or if the device is offline).

--- a/docs/guide-end-of-form.rst
+++ b/docs/guide-end-of-form.rst
@@ -9,11 +9,11 @@ By default, data collectors using Collect can save a form they're working on as 
 
 While these are good defaults for many contexts, some projects benefit from customizing how data collectors can interact with forms in the different states. In this guide, you will learn:
 
-* :ref:`what the Collect form states mean <guide-form-states-states-overview>`
-* :ref:`ways to customize how data collectors interact with forms <guide-form-states-customization-options>`
-* :ref:`example customizations to meet the needs of common workflows <guide-form-states-common-workflows>`
+* :ref:`what the Collect form states mean <guide-end-form-states-overview>`
+* :ref:`ways to customize how data collectors interact with forms <guide-end-form-customization-options>`
+* :ref:`example customizations to meet the needs of common workflows <guide-end-form-common-workflows>`
 
-.. _guide-form-states-states-overview:
+.. _guide-end-form-states-overview:
 
 Form states in Collect
 ----------------------------------
@@ -21,7 +21,7 @@ Form states in Collect
 Filled forms in ODK Collect can be in one of three states: ``draft``, ``finalized``, or ``sent``. State changes always happen in the same order: a ``draft`` form can only transition to the ``finalized`` state and a ``finalized`` form can only transition to the ``sent`` state.
 
 .. note::
-  Prior to Collect v2024.1, ``finalized`` forms could go back to the ``draft`` state. This was removed to better satisfy the goals of the ``finalized`` state described below. If your workflow previously relied on editing finalized forms, you can use this guide, especially the :ref:`section with example workflows <guide-form-states-common-workflows>`, to design an alternative.
+  Prior to Collect v2024.1, ``finalized`` forms could go back to the ``draft`` state. This was removed to better satisfy the goals of the ``finalized`` state described below. If your workflow previously relied on editing finalized forms, you can use this guide, especially the :ref:`section with example workflows <guide-end-form-common-workflows>`, to design an alternative.
 
 Draft
 ~~~~~~~
@@ -40,10 +40,10 @@ Finalized forms are ready to be sent and can't be edited. The ``finalized`` stat
 
 * give data collectors control over when filled forms are queued for submission.
 * reduce the risk that data collectors continue editing data after they no longer have access to the data collection subject.
-* prevent edits after an important workflow step is completed (for example, supervisor review)
+* prevent edits after an important workflow step is completed (for example, supervisor review).
 * let Collect do data processing with a guarantee that the data won't change (for example, creating :doc:`Entities <central-entities>`).
 
-The ``finalized`` state is only necessary because Collect allows users to save and work with data offline. If your data collectors are guaranteed to always have connectivity, you can turn on :ref:`Auto send <guide-form-states-auto-send>` so that they never need to see filled forms in the ``finalized`` state.
+The ``finalized`` state is only necessary because Collect allows users to save and work with data offline. If your data collectors are guaranteed to always have connectivity, you can turn on :ref:`Auto send <guide-end-form-auto-send>` so that they never need to see filled forms in the ``finalized`` state.
 
 Sent
 ~~~~~
@@ -55,7 +55,7 @@ Sent forms have been received by the server and can't be edited from Collect. Th
 
 Collect can also optionally be configured to :ref:`delete submissions after send <delete-after-send>` to reduce device storage needs or ensure greater data protection.
 
-.. _guide-form-states-customization-options:
+.. _guide-end-form-customization-options:
 
 Customization options
 -------------------------
@@ -64,9 +64,9 @@ This section describes ways to customize how data collectors interact with the f
 
 The settings described can be set on a device and then :ref:`shared by QR code to other devices <sharing-settings-with-another-device>`. Alternately, and especially if different devices need to use different App Users, you can :ref:`create your own QR codes <create-settings-qr-code>`.
 
-To see how these options can be combined to achieve specific goals, see :ref:`the customizations for common workflows section <guide-form-states-common-workflows>`.
+To see how these options can be combined to achieve specific goals, see :ref:`the customizations for common workflows section <guide-end-form-common-workflows>`.
 
-.. _guide-form-states-auto-send:
+.. _guide-end-form-auto-send:
 
 Auto send setting
 ~~~~~~~~~~~~~~~~~
@@ -74,13 +74,13 @@ Auto send setting
 We generally recommend turning on :guilabel:`auto send` in :ref:`form management settings <form-management-settings>`. When :guilabel:`auto send` is on, Collect attempts to send filled forms as soon as they are finalized. The benefits of :guilabel:`auto send` are:
 
 * reduced risk of data collectors forgetting to send data in a timely way.
-* more opportunities to retry sending. On poor or intermittent data connections, this can be very helpful.
-* less for data collectors to think about (and you can also :ref:`hide the Ready to send button <guide-form-states-hide-buttons>`).
+* more opportunities to retry sending. This can be very helpful on poor or intermittent Internet connections.
+* less for data collectors to think about (and you can also :ref:`hide the Ready to send button <guide-end-form-hide-buttons>`).
 * less chance that all data collectors send at the same time (such as the end of their work day) which could lead to network congestion or high load on the server.
 
 One case where you may need to turn :guilabel:`auto send` off is if it's important for data collectors to send data while on a network connection that is higher bandwidth, more secure, or lower-cost. In some cases, changing the setting to ``WiFi only`` or ``Cellular only`` may address these needs.
 
-.. _guide-form-states-hide-buttons:
+.. _guide-end-form-hide-buttons:
 
 Hide :guilabel:`Drafts`, :guilabel:`Ready to Send` and/or :guilabel:`Sent` buttons from Main Menu
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -115,7 +115,7 @@ You can also use :ref:`draft names <instance-name>` to include information about
 
 If you use a constraint as in the above example, the user will need to come back into the draft and change their answer to the question before they can send the data.
 
-If your users have many drafts, will only need to edit a few before sending them, but don't know which ones will need to be edited, you can use a ``note`` without a constraint to guide users to save as draft.
+If your users have many draft, will only need to edit a few before sending them, and don't know which ones will need to be edited, you can use a ``note`` without a constraint to guide users to save as draft.
 
 .. tip::
 
@@ -141,7 +141,7 @@ Collect's :ref:`protected access control settings <admin-settings>` also contain
 
 You may still want to allow them to save as draft from the form end screen if, for example, it's appropriate for them to make small edits after all of the initial data is captured.
 
-.. _guide-form-states-hide-save-draft-form-end:
+.. _guide-end-form-hide-save-draft-form-end:
 
 Remove :guilabel:`Save as draft` from the form end screen
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -155,7 +155,7 @@ Remove :guilabel:`Finalize all drafts` from the :guilabel:`Drafts` list
 
 If you want to guarantee that each draft is finalized from the form end screen, you can remove :guilabel:`Finalize all drafts` from the :ref:`protected access control settings <admin-settings>`. For example, if you want data collectors to verify each submission before finalizing it, you may not want them to bulk finalize.
 
-.. _guide-form-states-form-audit-log:
+.. _guide-end-form-form-audit-log:
 
 Capture data collector behavior in the form audit log
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -164,7 +164,7 @@ Collect's :doc:`audit logging <form-audit-log>` makes it possible to capture a r
 
 The amount of data captured by audit logging can appear overwhelming but it's not necessary to carefully analyze the logs to get value out of them. First, the very act of communicating to data collectors that their actions are being logged for quality assurance will make data collectors more mindful of how they interact with forms. Additionally, manually looking through the log for specific submissions during training or for submissions with unexpected data can provide valuable insights.
 
-.. _guide-form-states-admin-password:
+.. _guide-end-form-admin-password:
 
 Set an admin password
 ~~~~~~~~~~~~~~~~~~~~~
@@ -173,7 +173,7 @@ If your data collectors are likely to want to change some of the settings that a
 
 In many cases, the admin password will never need to be used: its purpose is only to lock down settings. In that case, it can be complex and hard to remember. In some cases, it may be necessary for someone in the field such as a supervisor to be able to change settings. In that case, it should be set to something relatively easy to communicate and enter.
 
-.. _guide-form-states-common-workflows:
+.. _guide-end-form-common-workflows:
 
 Customizations for common workflows
 ------------------------------------
@@ -186,7 +186,7 @@ Some questions to ask yourself and your data collectors as you design your workf
 * How many times will data collectors repeat the same workflow?
 * How capable are data collectors of making independent decisions when faced with unexpected situations like an interview being interrupted?
 * How trusted and well-trained are data collectors? Are they likely to want to "cheat" in some way to save time and/or effort?
-* Will data collectors be in a distracting or stressful environment that could reduce their usual capacities or honesty?
+* Will data collectors be in a distracting or stressful environment that could reduce their usual abilities?
 * What are the consequences of incorrect data being sent? What are the next steps if that happens and is detected?
 * How much workflow support do data collectors want to be included in the form(s) they use?
 
@@ -206,7 +206,7 @@ In many workflows, it's important to guarantee that data is not changed after th
 When data collectors reach the form end screen, they only have the option to :guilabel:`Finalize`. If they are interrupted during a form filling session, they need to exit and discard changes or rely on automatic data backups and recovery (the partially-filled form will open automatically when they open the same blank form again).
 
 .. note::
-  If you would still like to leave the door open to edits but they are generally strongly discouraged, you could leave the option to save as draft from the form filling experience and use :ref:`audit logging <guide-form-states-form-audit-log>` with change tracking and reasons for change to get more information on edits that are made.
+  If you would like to allow edits but they are generally strongly discouraged, you could leave the option to save as draft from the form filling experience and use :ref:`audit logging <guide-end-form-form-audit-log>` with change tracking and reasons for change to get more information on edits that are made.
 
 Edits are needed to specific, known drafts
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -218,17 +218,17 @@ Saving as draft and making edits can be an expected and important part of a work
 
 This can generally be addressed in form design by using required questions. You can also use a ``note``, a ``hint``, or a ``required_message`` to prompt users to exit the form and :guilabel:`Save as draft` at known points of the form.
 
-If you have designed your form so that it's only possible to reach the form end screen once all necessary tasks are complete, you may want to :ref:`hide the Save as draft button from the form end screen <guide-form-states-hide-save-draft-form-end>`. It can be easier for data collectors to take the right action if they always use the back button to save as draft and only use the form end screen to finalize/send.
+If you have designed your form so that it's only possible to reach the form end screen once all necessary tasks are complete, you may want to :ref:`hide the Save as draft button from the form end screen <guide-end-form-hide-save-draft-form-end>`. It can be easier for data collectors to take the right action if they always use the back button to save as draft and only use the form end screen to finalize/send.
 
-Edits are needed but it's not known ahead of time to which drafts
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-In other workflows, edits are needed but it is not known ahead of time which drafts will be edited. For example:
+Edits are needed but it's unknown in advance to which drafts
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+In other workflows, it is not known ahead of time which drafts will be edited. For example:
 
 * a data collection subject may be observable at different times or from different angles, revealing new information.
 * self-review to fix small mistakes like typos may be encouraged.
 
 .. warning::
-  Although self-review can be a powerful way to catch mistakes, it can also lead to accidental data fabrication. If you are considering this kind of workflow in a context where the data collection subject will no longer be available, consider running an experiment to measure whether allowing later edits improves or harms data quality. You may find it useful to turn on Collect's :ref:`audit logging <guide-form-states-form-audit-log>` and specifically to configure :ref:`change tracking <form-audit-log-change-tracking>`.
+  Although self-review can be a powerful way to catch mistakes, it can also lead to accidental data fabrication. If you are considering this kind of workflow in a context where the data collection subject will no longer be available, consider running an experiment to measure whether allowing later edits improves or harms data quality. You may find it useful to turn on Collect's :ref:`audit logging <guide-end-form-form-audit-log>` and specifically to configure :ref:`change tracking <form-audit-log-change-tracking>`.
 
 To support this need, you can take the :guilabel:`Finalize` / :guilabel:`Send` button off the form end screen and require that data collectors always use :ref:`bulk finalization <bulk-finalizing-drafts>`:
 

--- a/docs/guide-end-of-form.rst
+++ b/docs/guide-end-of-form.rst
@@ -115,7 +115,7 @@ You can also use :ref:`draft names <instance-name>` to include information about
 
 If you use a constraint as in the above example, the user will need to come back into the draft and change their answer to the question before they can send the data.
 
-If your users have many draft, will only need to edit a few before sending them, and don't know which ones will need to be edited, you can use a ``note`` without a constraint to guide users to save as draft.
+If your users have many drafts and don't know which ones will need to be edited before submission, you can use a ``note`` without a constraint to recommend that users save as draft.
 
 .. tip::
 


### PR DESCRIPTION
Thanks for the great feedback, @seadowg and @alyblenkin!

I believe I have addressed all other than:
- did not add image re-enforcing that send and finalize are the same action. I couldn't quickly figure out how to make it flow and I'm not sure we want to draw attention to that distinction, necessarily. Will think about it more.
- did not add a nudge to split the workflow into multiple forms. I couldn't find a great place to put it.