### PR TITLE
Recognize functions with dashes in their names

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,6 +59,8 @@ templates_path = ['_templates']
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
+# Set primary domain to JavaScript to allow dashes in function names
+primary_domain = 'js'
 
 # -- Options for HTML output -------------------------------------------------
 


### PR DESCRIPTION
I noticed recently that functions with dashes in their names weren't being correctly linked. It's because we lost https://github.com/getodk/docs/blob/de527759e1507c98f10bfba7102bddaebdd76b16/docs/conf.old.py#L118 when we switched to Furo.

Shoutout to @dgw for [the help](https://github.com/pradyunsg/furo/discussions/767#discussioncomment-8401830)!