### PR TITLE
Add margin above reactions

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -64,7 +64,7 @@ details.sd-dropdown details.nested-schema[open] > summary:first-of-type{
 }
 
 .reactions {
-    margin: 1em auto;
+    margin: 3em auto 1em auto;
     padding: 0.5em 1.5em;
     display: table;
     border: 1px solid #ccc;


### PR DESCRIPTION
Things were too cramped.

<img width="532" alt="Screenshot 2024-02-08 at 12 49 50 PM" src="https://github.com/getodk/docs/assets/967540/b7b8f370-eefd-4d21-9dd4-1ae538ef946b">

<img width="600" alt="Screenshot 2024-02-08 at 12 50 54 PM" src="https://github.com/getodk/docs/assets/967540/f25f0af0-ca33-441d-8594-851d8e9bae1a">
