### PR TITLE
Fix response json example for http 200 on entity deletion

### DIFF
--- a/docs/_static/api-spec/central.yaml
+++ b/docs/_static/api-spec/central.yaml
@@ -10290,7 +10290,14 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Success'
+                required:
+                - success
+                type: object
+                properties:
+                  success:
+                    type: boolean
+              example:
+                success: true
         403:
           description: Forbidden
           content:


### PR DESCRIPTION
#### What is included in this PR?

- For the [Deleting an Entity](https://docs.getodk.org/central-api-entity-management/#deleting-an-entity) section in the Central API docs, the response example for a HTTP 200 is incorrect.
- The docs state that it is a JSON response, with a string value {'message': 'success'}:

![image](https://github.com/getodk/docs/assets/78538841/559a9498-de3f-4fa4-90fc-125097b1abc5)

- In fact, on testing, the actual response is a JSON with bool value `{'success': True}`.
- I updated the docs to reflect this.

#### Context

- I wasn't sure if the OpenAPI docs are auto-generated somehow, but I made a PR anyway to update the yaml manually.
- Feel free to close this PR and update the upstream if that is the case.