### PR TITLE
Describe savepoint recovery

### DIFF
--- a/docs/collect-filling-forms.rst
+++ b/docs/collect-filling-forms.rst
@@ -131,7 +131,7 @@ If you have a repeating group, you can remove existing instances of that repeat 
 Navigating the form 
 ------------------------
 
-By default, you can go between form screens either by swiping left or right on the screen or by using the Next and Back buttons above the keyboard. You can allow only one of the navigation modes by changing :doc:`collect-settings`. You can also change navigation mode settings while filling out a form by using :menuselection:`⋮ -> Project settings -> User Interface`.
+By default, you can go between form screens either by swiping left or right on the screen or by using the Next and Back buttons at the bottom of the screen. You can allow only one of the navigation modes by changing :doc:`collect-settings`. You can also change navigation mode settings while filling out a form by using :menuselection:`⋮ -> Project settings -> User Interface`.
 
 Swiping
 ~~~~~~~~~~
@@ -145,7 +145,7 @@ Swiping left or right anywhere on the screen can be a quick way to move between 
 Next and Back Buttons  
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Next and Back buttons are included above the keyboard by default. These are generally more intuitive to use than swipes but they may take up more vertical space than desired on short devices.
+Next and Back buttons are included at the bottom of the screen by default. These are generally more intuitive to use than swipes but they may take up more vertical space than desired on short devices.
 
 .. _jumping:
 

--- a/docs/collect-filling-forms.rst
+++ b/docs/collect-filling-forms.rst
@@ -197,10 +197,31 @@ Required Questions
   :alt: A question screen in the Collect app. An error text reads, "Sorry, this response is required."
   :class: device-screen-vertical
 
+Recovering data after Collect quits
+-------------------------------------
+
+As you fill out a form, Collect automatically saves your data each time you change question screens. It will also attempt to save when you switch to another app or it detects a force close. For example, this can happen if Android closes Collect to free up device memory.
+
+If Collect quits unexpectedly, you will be prompted to recover saved data the next time that you open the blank form or filled form that was open at the time of the force close.
+
+For example, if you start a new blank copy of "Form1", fill out some data, and then Collect closes, you will be prompted to recover that data the next time that you select "Form1" from the :guilabel:`Start new form` menu.
+
+If you start a new blank copy of "Form1", fill out some data, explicitly save it to create the "Smith Household" draft and then Collect closes, you will be prompted to recover the saved data the next time that you open "Smith Household" from the :guilabel:`Drafts` menu.
+
+.. image:: /img/collect-filling-forms/recover-from-savepoint.*
+  :alt: A dialog with title "Recover your work?" and options to Discard or Recover.
+  :class: device-screen-vertical
+
+If you choose to discard, the recovery data is permanently deleted and cannot be recovered.
+
+If you choose to recover your work, Collect will open the saved data for editing. If you find that you don't want that data after all, you can use your back button to exit the form filling screen and choose to discard changes. Once you have discarded the recovery data in this way, it is permanently deleted and cannot be recovered.
+
+If you've updated your form since Collect closed unexpectedly, Collect will prompt you to recover saved data. If you choose to recover your work, it will open that saved data with the form version that was used to create the saved data, not the updated version.
+
 .. _change-form-language:  
 
-Changing language of a form
------------------------------
+Changing the language of a form
+--------------------------------
 
 If a form is available in multiple languages, you can choose a language in which you want the questions to appear. This is separate from the Collect application language which is set by the device settings by default or can be manually selected from :doc:`Settings <collect-settings>`.
 
@@ -222,7 +243,7 @@ Open the *Action Menu* (:menuselection:`⋮`) and select :guilabel:`Change Langu
 
 .. _validate_form:  
 
-Check for errors during form entry
+Checking for errors during form entry
 ---------------------------------------
 
 As of Collect v2023.2.0, you can check a form for errors (validate it) during the form entry process at any stage.

--- a/docs/collect-filling-forms.rst
+++ b/docs/collect-filling-forms.rst
@@ -26,6 +26,7 @@ Free response
 Free-entry text and number answers are entered using the device keyboard. The appropriate keyboard (letters or numbers) opens when the question appears.
 
 .. video:: /vid/collect-filling-forms/keyboard-popup.mp4
+  :class: device-screen-vertical
 
   Video showing text keyboard popup when a string input is required and number keyboard popup when a number input is required.
 
@@ -130,13 +131,12 @@ If you have a repeating group, you can remove existing instances of that repeat 
 Navigating the form 
 ------------------------
 
-.. note::
-  Since Collect v1.29, both swiping and button navigation are enabled by default on new installations. Prior to Collect v1.29 or for existing installations, only swiping was enabled by default.
+By default, you can go between form screens either by swiping left or right on the screen or by using the Next and Back buttons above the keyboard. You can allow only one of the navigation modes by changing :doc:`collect-settings`. You can also change navigation mode settings while filling out a form by using :menuselection:`⋮ -> Project settings -> User Interface`.
 
-Swipe
+Swiping
 ~~~~~~~~~~
 
-To move between questions, Swipe Left or Right. 
+Swiping left or right anywhere on the screen can be a quick way to move between questions. For a swipe to be recognized as a page change request, it has to be fast and close to straight across. This may require some explicit training and practice.
 
 .. image:: /img/collect-filling-forms/swiping.* 
   :alt: A question screen in the Collect App. Overlaid on the screen is an icon of a hand with extended finger and arrows pointing left and right, representing a swiping gesture.
@@ -145,48 +145,14 @@ To move between questions, Swipe Left or Right.
 Next and Back Buttons  
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you prefer Next and Back buttons for navigation, you can change your navigation mode in :menuselection:`⋮ -> Project settings -> User Interface`.
-
-1. Open the *Action Menu* (:menuselection:`⋮`)
-
-   .. image:: /img/collect-filling-forms/question-screen-highlight-kebab.* 
-     :alt: A question screen in the Collect app. The Action Menu ("kebab") in the top-right corner is circled in red.
-     :class: device-screen-vertical
-
-2. Select :menuselection:`Project settings`.
-
-   .. image:: /img/collect-filling-forms/question-screen-highlight-general-settings.* 
-     :alt: A question screen in the Collect app. The Action Menu is expanded and the option *General Settings* is circled in red.
-     :class: device-screen-vertical
-
-3. Select :menuselection:`User Interface`
-
-   .. image:: /img/collect-filling-forms/general-settings-highlight-user-interface.* 
-     :alt: The General Settings menu of the Collect app. The *User Interface* item is circled in red.
-     :class: device-screen-vertical
-  
-4. Select :menuselection:`Navigation`
-
-   .. image:: /img/collect-filling-forms/user-interface-highlight-navigation.* 
-     :alt: The User Interface menu of the Collect app. The *Navigation* item is circled in red.
-     :class: device-screen-vertical
-
-5. Update your form navigation preference  
-
-   .. image:: /img/collect-filling-forms/ui-navigation-buttons.* 
-     :alt: The User Interface menu of the Collect app, as displayed in the previous image. There is now a modal titled *Navigation*, with radio buttons (single select) for: *Use horizontal swipes*, *Use forward/back buttons*, and *Use swipes and buttons*. The option for *Use forward/back buttons* is selected and circled in red.
-     :class: device-screen-vertical
-  
-.. image:: /img/collect-filling-forms/question-screen-with-buttons.* 
-  :alt: A question screen in the Collect App. There are now two buttons below the question text, with left (backwards) and right (forwards) buttons.
-  :class: device-screen-vertical
+Next and Back buttons are included above the keyboard by default. These are generally more intuitive to use than swipes but they may take up more vertical space than desired on short devices.
 
 .. _jumping:
 
 Jumping to questions
 ~~~~~~~~~~~~~~~~~~~~~~
   
-The arrow icon (|arrow|) in the top right corner opens the jump menu. From the jump menu, you can go to any question or go to the beginning/ending of the form.
+The arrow icon (|arrow|) in the top right corner opens the summary. From the summary view, you can go to any question or go to the beginning or ending of the form.
 
 .. |arrow| image:: /img/collect-forms/jumpicon.*
     :alt: Opens the jump menu.

--- a/docs/collect-settings.rst
+++ b/docs/collect-settings.rst
@@ -99,13 +99,13 @@ To access User Interface settings:
 
 :guilabel:`Navigation`
 """""""""""""""""""""""
-  Sets form navigation style for moving between questions.
+  Sets navigation style for moving between questions in a form.
 
   Options:
 
   - Horizontal swiping
   - Forward and back buttons
-  - Both
+  - Both (default)
 
 .. _mapping-settings:
 

--- a/docs/img/collect-filling-forms/general-settings-highlight-user-interface.png
+++ b/docs/img/collect-filling-forms/general-settings-highlight-user-interface.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dd60b32dc0ca2c28d7c19dba8c515a16777384211349677dfe46052da15e591c
-size 57333

--- a/docs/img/collect-filling-forms/question-screen-highlight-general-settings.png
+++ b/docs/img/collect-filling-forms/question-screen-highlight-general-settings.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dcab2cfc59780447ee88933066bb4c4425256080015846f6c983077a3a783abf
-size 87060

--- a/docs/img/collect-filling-forms/question-screen-with-buttons.png
+++ b/docs/img/collect-filling-forms/question-screen-with-buttons.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5509495143f6c008873eee5fca297265b623f08bbdbf366416831f418729e37c
-size 63523

--- a/docs/img/collect-filling-forms/recover-from-savepoint.png
+++ b/docs/img/collect-filling-forms/recover-from-savepoint.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d75914b9fc9c0c6e9fa76fe3e88825318b2617aa6a539d745752abd0bb672df
+size 99472

--- a/docs/img/collect-filling-forms/ui-navigation-buttons.png
+++ b/docs/img/collect-filling-forms/ui-navigation-buttons.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:aa1d670bfa8541a45bd8bbe44d92f08c1ceff307b4aba6c201863c566838fe88
-size 99254

--- a/docs/img/collect-filling-forms/user-interface-highlight-navigation.png
+++ b/docs/img/collect-filling-forms/user-interface-highlight-navigation.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:57add298d3f0dfa9981792bb61731e2e4dc7990ec3046f09bc5df8504ff8e7ee
-size 92179


### PR DESCRIPTION
Closes https://github.com/getodk/docs/issues/1463

I decided not to go into very much detail about form versions because I think it mostly works as people expect. I think the one potentially surprising case is if you open form version 4 and there's recovery data that was saved with version 2, the recovery data will be opened with version 2, not version 4 (related to https://github.com/getodk/collect/issues/5947).

@alyblenkin 