### PR TITLE
Text Import Wizard is deprecated

### DIFF
--- a/docs/central-submissions.rst
+++ b/docs/central-submissions.rst
@@ -125,7 +125,7 @@ Once the :file:`.csv` or :file:`.zip` completes downloading, you will find one o
 
 .. tip::
 
-  Excel will not import CSVs with Unicode characters like ã, ß, and 箸 correctly if you double-click the file or open it from the File menu. You must use the `Text Import Wizard <https://support.microsoft.com/en-us/office/text-import-wizard-c5b02af6-fda1-4440-899f-f78bafe41857>`_ and specify a file origin of Unicode (UTF-8, 65001) and the comma delimiter.
+  Excel will not import CSVs with Unicode characters like ã, ß, and 箸 correctly if you double-click the file or open it from the File menu. You must instead use Power Query. Go to the :guilabel:`Data` tab, and in the :guilabel:`Get & Transform Data` group, click :guilabel:`From Text/CSV`.
 
   Rather than downloading CSVs manually, you can also :ref:`connect Excel directly to Central via OData <central-submissions-odata>` and get a live-updating spreadsheet with auto-detected data types and Unicode support.
 


### PR DESCRIPTION
As described at https://forum.getodk.org/t/poorly-formatted-csv-export/47980/15

I tried to use the language in the "Import a text file by connecting to it" section at the bottom of https://support.microsoft.com/en-us/office/import-or-export-text-txt-or-csv-files-5250ac4c-663c-47ce-937b-339e391393ba#ID0EBBN=Newer_versions but also use the word "Power Query" as a hint for older versions of Excel.

