### PR TITLE
Makefile: mark autobuild target as PHONY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ help:
 
 .PHONY: help Makefile
 
+.PHONY: autobuild
 autobuild:
 	sphinx-autobuild -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)/html" --re-ignore "central-api|_build" --host 0.0.0.0
 


### PR DESCRIPTION
> A phony target is one that is not really the name of a file; rather it is just a name for a recipe to be executed when you make an explicit request. There are two reasons to use a phony target: to avoid a conflict with a file of the same name, and to improve performance.

See: https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html
