### PR TITLE
Add info to ensure `pgrowlocks` is installed for S3 on custom DBs

### DIFF
--- a/docs/central-install-digital-ocean.rst
+++ b/docs/central-install-digital-ocean.rst
@@ -470,6 +470,7 @@ Central comes with a PostgreSQL v14.x database server to store your data. To use
 
       CREATE EXTENSION IF NOT EXISTS CITEXT;
       CREATE EXTENSION IF NOT EXISTS pg_trgm;
+      CREATE EXTENSION IF NOT EXISTS pgrowlocks;
 
 #. Edit ``.env`` with your database server host, database name, and authentication details.
 

--- a/docs/central-install-digital-ocean.rst
+++ b/docs/central-install-digital-ocean.rst
@@ -579,6 +579,11 @@ To use S3-compatible storage for all files saved in Central, follow these steps:
 
      $ docker compose exec service node lib/bin/s3.js upload-pending 1
 
+   .. note::
+
+     If you are using a custom database,
+     :ref:`ensure all required extensions are installed <central-install-digital-ocean-custom-db>`.
+
    If the configuration is correct, you should see a success message. If there are issues with the configuration, you should see an error message with hints on what needs to be fixed. To try uploading the same file again, you will need to reset its status to pending:
 
    .. code-block:: bash


### PR DESCRIPTION
### Issue

- I was setting up external S3 for Central today.
- I wanted to test manual syncing using `node lib/bin/s3.js upload-pending 1`.
- The `pgrowlocks` Postgres extension was not installed in the db, causing an error.

### Solution

- Added the extension to the [Using a custom database](https://docs.getodk.org/central-install-digital-ocean/#using-a-custom-database-server) section during install.
    ![image](https://github.com/user-attachments/assets/1efdc4f8-7865-4f16-b4bd-07338f2fb9e5)

- Referenced the extension install in the [Using S3-compatible storage](https://docs.getodk.org/central-install-digital-ocean/#using-s3-compatible-storage) section, to help users debug if they encounter an error setting this up (linking to the 'Using a custom database' section).

    ![image](https://github.com/user-attachments/assets/cc796c55-756b-41b3-a287-f5b8c9e1330f)
