### PR TITLE
getodk/central#817 : fix redis container umask-at-clone-time sensitivity

### DIFF
--- a/docs/central-install-digital-ocean.rst
+++ b/docs/central-install-digital-ocean.rst
@@ -112,7 +112,7 @@ If you are using old versions, follow the instructions to install `Docker Engine
 
    .. code-block:: bash
 
-     $ umask 022; git clone https://github.com/getodk/central
+     $ umask 022; git clone --shallow-submodules --recurse-submodules https://github.com/getodk/central
 
    and press **Enter**. It should think for some time and download many things.
 
@@ -121,12 +121,6 @@ If you are using old versions, follow the instructions to install `Docker Engine
    .. code-block:: bash
 
      $ cd central
-
-#. Get the latest client and server:
-
-   .. code-block:: bash
-
-     $ git submodule update -i
 
 #. Update settings. First, copy the settings template file so you can edit it:
 

--- a/docs/central-install-digital-ocean.rst
+++ b/docs/central-install-digital-ocean.rst
@@ -112,7 +112,7 @@ If you are using old versions, follow the instructions to install `Docker Engine
 
    .. code-block:: bash
 
-     $ umask 022; git clone --shallow-submodules --recurse-submodules https://github.com/getodk/central
+     $ umask 022; git clone https://github.com/getodk/central
 
    and press **Enter**. It should think for some time and download many things.
 
@@ -121,6 +121,12 @@ If you are using old versions, follow the instructions to install `Docker Engine
    .. code-block:: bash
 
      $ cd central
+
+#. Get the latest client and server:
+
+   .. code-block:: bash
+
+     $ git submodule update -i
 
 #. Update settings. First, copy the settings template file so you can edit it:
 

--- a/docs/central-install-digital-ocean.rst
+++ b/docs/central-install-digital-ocean.rst
@@ -112,7 +112,7 @@ If you are using old versions, follow the instructions to install `Docker Engine
 
    .. code-block:: bash
 
-     $ git clone https://github.com/getodk/central
+     $ umask 022; git clone https://github.com/getodk/central
 
    and press **Enter**. It should think for some time and download many things.
 


### PR DESCRIPTION
fixes getodk/central#817


#### What is included in this PR?

Two commits:

- 04e7943 fixes getodk/central#817
- b2082fa simplifies things by removing a step (by cloning the submodules in the same operation as cloning the central repo)