### PR TITLE
Drop support for J2ME

### DIFF
--- a/docs/openrosa-form-submission.rst
+++ b/docs/openrosa-form-submission.rst
@@ -25,8 +25,6 @@ OpenRosa servers MUST provide a URI capable of accepting HTTP POST Requests. Acc
 
 The server MUST support HTTP 1.1 chunked transfer encoding for receiving the POST content. There is no minimum set of standards for timeouts, maximum content length, or other http configurations, but servers are encouraged to support lenient connections and the largest possible content size, since many of the connections will be from unreliable channels and in environments where splitting content up is impractical.
 
-For maximum compatibility with J2ME clients, it is recommended that a server SHOULD NOT issue redirects. 
-
 .. note::
   Using digest authentication and https when communicating with a server does not require any redirects --- you can have authentication and secure transport without redirects.
 


### PR DESCRIPTION
It seems unlikely that J2ME is still supported:

* it was renamed Java ME in 2006
* ODK Central recently introduced redirects when using s3 storage
* Collect began supporting redirects at least 5 years ago https://github.com/getodk/collect/blame/0f07d51e8c1bbe34c50f2a47e7c7ad01d0a535e2/collect_app/src/main/java/org/odk/collect/android/openrosa/okhttp/OkHttpOpenRosaServerClientProvider.java#L88 (they may have been supported prior to that)