### PR TITLE
Add documentation for integrity URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Please [file an issue](https://github.com/getodk/docs/issues) if you can't find 
 
 We highly recommend you use a virtual environment like [`virtualenv`](https://virtualenv.pypa.io/en/stable/). If you need to use different versions of Python, we recommend [`pyenv`](https://github.com/pyenv/pyenv).
 
+You can also use Docker to build and view the docs:
+
+```bash
+make autobuild-docker
+```
+
 ### Cloning the repo
 
 Clone the docs repo and make sure all the requirements are installed:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,8 @@ extensions = [ 'sphinxcontrib.spelling',
     'openapi',
     'sphinxext.opengraph',
     'notfound.extension',
-    'sphinx_sitemap'
+    'sphinx_sitemap',
+    'myst_parser'
 ]
 
 # If using Apple Silicon, set env variable (assumes brew install of enchant)

--- a/docs/openrosa-form-list.rst
+++ b/docs/openrosa-form-list.rst
@@ -208,7 +208,7 @@ Elements within ``<mediaFile/>``
 -  ``<filename/>`` The unique un-rooted file path for this media file. This un-rooted path must not start with a drive name or slash and must not contain relative path navigations (for example, ``.`` or ``..``).
 -  ``<hash/>`` The hash value of the media file available for download. The only hash values currently supported are MD5 hashes of the file contents; they are prefixed by ``md5:``. If the hash value identified in the manifest differs from the hash value for a previously-downloaded media file, then the file should be re-fetched from the server.
 -  ``<downloadUrl/>`` A fully qualified URI for downloading the media file to the device. It may be a valid http or https URI of any structure; the server may require authentication; the server may require a secure (https) channel, etc.
--  ``<integrityUrl/>`` A fully qualified URI for using the :doc:`Integrity API <openrosa-integrity>` for this media file.
+-  ``<integrityUrl/>`` A fully qualified URI for using the :doc:`Integrity API <openrosa-integrity>` for this media file. This is optional, but must be present if the media file has the ``type`` attribute with the value ``entityList``.
 
 ``<mediaFile/>`` attributes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/openrosa-form-list.rst
+++ b/docs/openrosa-form-list.rst
@@ -208,6 +208,7 @@ Elements within ``<mediaFile/>``
 -  ``<filename/>`` The unique un-rooted file path for this media file. This un-rooted path must not start with a drive name or slash and must not contain relative path navigations (for example, ``.`` or ``..``).
 -  ``<hash/>`` The hash value of the media file available for download. The only hash values currently supported are MD5 hashes of the file contents; they are prefixed by ``md5:``. If the hash value identified in the manifest differs from the hash value for a previously-downloaded media file, then the file should be re-fetched from the server.
 -  ``<downloadUrl/>`` A fully qualified URI for downloading the media file to the device. It may be a valid http or https URI of any structure; the server may require authentication; the server may require a secure (https) channel, etc.
+-  ``<integrityUrl/>`` A fully qualified URI for using the :doc:`Integrity API <openrosa-integrity>` for this media file.
 
 ``<mediaFile/>`` attributes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/openrosa-integrity.md
+++ b/docs/openrosa-integrity.md
@@ -21,7 +21,7 @@ The structure of the integrity document returned by an integrity request is as f
 <data>
 <entities>
     <entity id="24b47424-ccf8-4f4b-b4cd-34ff5c71eddd">
-        deleted>true</deleted>
+        <deleted>true</deleted>
     </entity>
     <entity id="9e32d18f-d51a-4826-a8b2-e9b1c6d10b58">
         <deleted>false</deleted>

--- a/docs/openrosa-integrity.md
+++ b/docs/openrosa-integrity.md
@@ -17,7 +17,7 @@ This request will return an integrity document.
 The structure of the integrity document returned by an integrity request is as follows:
 
 ```xml
-<?xml version='1.0' encoding='UTF-8' ?>
+<?xml version='1.0' encoding='UTF-8'?>
 <data>
 <entities>
     <entity id="24b47424-ccf8-4f4b-b4cd-34ff5c71eddd">

--- a/docs/openrosa-integrity.md
+++ b/docs/openrosa-integrity.md
@@ -1,0 +1,44 @@
+# Integrity API
+
+This standard defines how clients can check the integrity of entity lists that are attached to forms as media files.
+
+## Integrity request
+
+Integrity requests can be made with an HTTP `GET` request to the server provided integrity URL with a comma-separated `id` query parameter specifying the ids of entities being checked. For example:
+
+```
+https://example.com/integrity?id=1,2,3
+```
+
+This request will return an integrity document.
+
+### Integrity document
+
+The structure of the integrity document returned by an integrity request is as follows:
+
+```xml
+<?xml version='1.0' encoding='UTF-8' ?>
+<data>
+<entities>
+    <entity id="24b47424-ccf8-4f4b-b4cd-34ff5c71eddd">
+        deleted>true</deleted>
+    </entity>
+    <entity id="9e32d18f-d51a-4826-a8b2-e9b1c6d10b58">
+        <deleted>false</deleted>
+    </entity>
+</entities>
+</data>
+```
+
+This document consists of:
+
+- A top-level `<data/>` tag in the `http://openrosa.org/xforms/xformsIntegrity` namespace enclosing:
+  - zero or more `<entity/>` tags containing a exactly one `<deleted/>` tag
+
+#### Elements with `<entity/>`
+
+- `<deleted/>` should contain `true` if the entity has been deleted on the server, and `false` if not
+
+#### `<entity/>` attributes
+
+- `id`: id of the entity

--- a/docs/openrosa-integrity.md
+++ b/docs/openrosa-integrity.md
@@ -19,21 +19,22 @@ The structure of the integrity document returned by an integrity request is as f
 ```xml
 <?xml version='1.0' encoding='UTF-8'?>
 <data>
-<entities>
-    <entity id="24b47424-ccf8-4f4b-b4cd-34ff5c71eddd">
-        <deleted>true</deleted>
-    </entity>
-    <entity id="9e32d18f-d51a-4826-a8b2-e9b1c6d10b58">
-        <deleted>false</deleted>
-    </entity>
-</entities>
+  <entities>
+      <entity id="24b47424-ccf8-4f4b-b4cd-34ff5c71eddd">
+          <deleted>true</deleted>
+      </entity>
+      <entity id="9e32d18f-d51a-4826-a8b2-e9b1c6d10b58">
+          <deleted>false</deleted>
+      </entity>
+  </entities>
 </data>
 ```
 
 This document consists of:
 
 - A top-level `<data/>` tag enclosing:
-  - zero or more `<entity/>` tags containing a exactly one `<deleted/>` tag
+  - an `entities` tag enclosing:
+    - zero or more `<entity/>` tags containing a exactly one `<deleted/>` tag
 
 #### Elements with `<entity/>`
 

--- a/docs/openrosa-integrity.md
+++ b/docs/openrosa-integrity.md
@@ -32,7 +32,7 @@ The structure of the integrity document returned by an integrity request is as f
 
 This document consists of:
 
-- A top-level `<data/>` tag in the `http://openrosa.org/xforms/xformsIntegrity` namespace enclosing:
+- A top-level `<data/>` tag enclosing:
   - zero or more `<entity/>` tags containing a exactly one `<deleted/>` tag
 
 #### Elements with `<entity/>`

--- a/docs/openrosa.rst
+++ b/docs/openrosa.rst
@@ -23,3 +23,4 @@ OpenRosa 1.0 APIs were formally approved by the OpenRosa Working Group in Decemb
   openrosa-authentication
   openrosa-form-submission
   openrosa-form-list
+  openrosa-integrity

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ pyyaml
 sphinxext-opengraph
 sphinx-notfound-page
 sphinx-sitemap
+myst-parser


### PR DESCRIPTION
Adds docs for the spec discussed in [this forum post](https://forum.getodk.org/t/openrosa-spec-proposal-support-offline-entities/48052)

#### What is included in this PR?

- Specification for `<integrityUrl/>` in the manifest
- A new page detailing the integrity API

#### What problems did you encounter?

I always struggle with using reST, so I added Markdown support using [MyST](https://myst-parser.readthedocs.io/en/latest/). I also had trouble working out how to use the included `Dockerfile`, so I added a note to the `README` about that.
