### PR TITLE
Document ODK Web Forms and new way of getting offline-capable Enketo links

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -31,6 +31,10 @@
     width: 365px;
 }
 
+.central-partial-screen {
+    width: 400px;
+}
+
 table.schema-table-wrap {
     width: 100%;    
 }

--- a/docs/central-submissions.rst
+++ b/docs/central-submissions.rst
@@ -3,39 +3,54 @@
 Managing Submissions in Central
 ===============================
 
-The most common way to use ODK Central is in conjunction with a data collection client, typically on a mobile device, such as ODK Collect. To do this, you will need to :ref:`connect to it from your mobile device <central-users-app-configure>`, after which you will be able to :ref:`upload submissions <uploading-forms>` back to Central.
+When users fill out forms and submit them, Central receives Submissions. Central users with the right roles can then :ref:`manage those Submissions <central-submissions-accessing>` directly in Central, :ref:`download them <central-submissions-download>`, or :ref:`connect to them <central-submissions-odata>` from an external tool like Excel.
 
-ODK Central also bundles `Enketo <https://enketo.org>`_, which enables preview and submission of forms directly from a web browser. Please note that as with all ODK clients, Enketo does not always behave quite the same as Collect, or support the same features. Any authorized Web User may fill out a Form directly from the browser, as will be described in more detail below.
+.. _central-web-submissions:
 
-Finally, ODK Central offers Public Access Links. A Public Access Link grants anybody in possession of the link the ability to submit to a Form on your server. You can control whether each respondent can submit more than once, and revoke access from any Link at any time.
+Making Submissions from the web
+---------------------------------
 
-Submissions sent to Central are available to browse in a preview table, to connect directly to data analysis tools, and for download.
+In general, we recommend using the :doc:`ODK Collect Android application <collect-intro>` when doing enumerator-mediated data collection, especially in offline conditions or when using multiple forms for a single project. To do this, you will need to :ref:`connect to Central from your mobile device <central-users-app-configure>`, and then you will be able to :ref:`send submissions <uploading-forms>` back to Central. However, there are many scenarios in which web forms may be more appropriate:
+
+* Self-report. Use single-submission :ref:`Public Access Links <central-submissions-public-link>` that participants can fill out from any device.
+* Public surveys. Use :ref:`Public Access Links <central-submissions-public-link>` and share them on a poster as a QR code, by email, etc.
+* Non-Android mobile devices. You can give enumerators :ref:`Data Collector roles <central-users-web-roles>` in your project or send :ref:`Public Access Links <central-submissions-public-link>` for them to bookmark.
+* Data entry from paper forms. Web forms can be used at a computer with a keyboard to quickly transcribe data collected on paper.
+
+ODK Central bundles `Enketo <https://enketo.org>`_ to enable editing, previewing and submitting forms directly from a web browser.
+
+.. note::
+
+  Enketo does not always behave exactly like Collect, or support all the same features. The :doc:`XLSForm template <xlsform>` provides compatibility information and we recommend testing your form as you expect users to interact with it.
+
+Any authorized Web User may fill out a Form directly from the browser, as will be described in more detail below. Additionally, ODK Central offers Public Access Links which grant anybody in possession of the link the ability to submit to a Form on your server. You can control whether each respondent can submit more than once, and revoke access from any Link at any time. It is also possible to make Enketo web forms :ref:`usable while offline <central-offline-web-forms>`.
 
 .. _central-submissions-direct:
 
 Direct Web Browser Submissions
-------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Web Users who are Administrators, Project Managers, or Data Collectors can directly fill Forms in the web browser from the Central administration website. This functionality is provided by Enketo, which does not always behave quite the same as Collect, or support the same features.
 
-   .. image:: /img/central-submissions/new.png
+.. image:: /img/central-submissions/new.png
 
 Administrators and Project Managers can begin a survey by going to the :guilabel:`Submissions` tab of the Form, and clicking on the :guilabel:`New` button next to the Submissions header. This will open a new tab which will load the Form in Enketo.
 
-   .. image:: /img/central-submissions/data-collector-form-listing.png
+.. image:: /img/central-submissions/data-collector-form-listing.png
 
 Data Collectors do not have access to the detailed Form management pages. Instead, they will find a :guilabel:`Fill Form` button next to the Form name in the list of Forms on the Project Overview page.
 
 .. _central-submissions-public-link:
 
 Public Access Links
--------------------
+~~~~~~~~~~~~~~~~~~~
 
 ODK Central allows the distribution of surveys to a broad or open respondent group using Public Access Links. These Links take recipients directly to the Form in their web browser, administered by Enketo.
 
 To create a Public Access Link, go to the Form's :guilabel:`Public Access` tab. Click on :guilabel:`Create Public Access Link…` to begin.
 
-   .. image:: /img/central-submissions/public-link-new.png
+.. image:: /img/central-submissions/public-link-new.png
+   :class: central-partial-screen
 
 In the window that appears, you'll need to name the Link. This name is for your own identification purposes in the administration website, and is not displayed to respondents.
 
@@ -49,14 +64,14 @@ You'll also need to decide whether to allow multiple submissions per respondent.
 
 Once a Link is created, it will appear in the table, along with a web address you can copy and paste to distribute the Link to respondents.
 
-   .. image:: /img/central-submissions/public-link-listing.png
+.. image:: /img/central-submissions/public-link-listing.png
 
-You cannot yet edit any of the details of a Public Link. This will come in a future version of Central.
+You cannot yet edit any of the details of a Public Link.
 
 .. _central-submissions-link-revoke:
 
 Revoking a Link
-~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^
 
 You can revoke a Link at any time to prevent any further Submissions through it. Once a Link is revoked, all Submissions will be immediately denied, and new attempts to load the Form using the Link will result in an error instead.
 
@@ -69,7 +84,7 @@ Accessing Submissions
 
 To find the Form submissions page, first find the form in the Form listings page (:menuselection:`--> Forms`) and click on it. You will be taken to the :ref:`Form Overview <central-forms-checklist>` page for that form. Click on the :menuselection:`--> Submissions` tab below the form name to find the submissions.
 
-   .. image:: /img/central-submissions/listing.png
+.. image:: /img/central-submissions/listing.png
 
 The table preview you see here will at first show you the first ten fields of your survey and their results, with the latest submissions shown closest to the top. Any downloadable files will appear with a green download link you can use to directly download that media attachment. The submission's instance ID will always be shown at the right side of this preview table.
 
@@ -90,12 +105,12 @@ Learn more about these options below:
 
 .. _central-submissions-download:
 
-Downloading submissions as CSVs
+Downloading Submissions as CSVs
 -------------------------------
 
 To download all submission data as :file:`.csv` tables, click on the :guilabel:`Download all # records` button on the right side of the listing page:
 
-   .. image:: /img/central-submissions/download-button.png
+.. image:: /img/central-submissions/download-button.png
 
 If you have any row filters applied to the submission table, those filters will be applied to your download as well. You can use this to, for example, download only submissions from a particular month, or only approved submissions.
 
@@ -106,7 +121,8 @@ Export options
 
 Once the download dialog opens, you'll be given some additional export options.
 
-   .. image:: /img/central-submissions/download-modal.png
+.. image:: /img/central-submissions/download-modal.png
+   :class: central-partial-screen
 
 Some of the options may be disabled if they do not apply to your data, or if they are not available due to features that you have enabled (such as managed encryption).
 
@@ -228,10 +244,10 @@ Once submissions have been reviewed, the submission table download and the OData
 
 .. _central-submissions-details:
 
-Submission Details
-------------------
+Viewing Submission Details
+--------------------------
 
-As of version 1.2, each submission has its own detail page which provides basic information about the submission, an activity history of action and discussion on that submission, and tools for updating the submission review state and data itself.
+Each submission has its own detail page which provides basic information about the submission, an activity history of action and discussion on that submission, and tools for updating the submission review state and data itself.
 
 .. image:: /img/central-submissions/details.png
 
@@ -246,8 +262,8 @@ You can leave a note when you update the review state, to indicate why the decis
 
 .. _central-submissions-editing:
 
-Submission Editing
-------------------
+Editing Submissions
+--------------------
 
 From the :ref:`submission detail page <central-submissions-details>` you can press the :guilabel:`Edit` button to edit the submission in your web browser. When an edited submission is resubmitted, a new version of it is created, just like a form version. You will be able to see previous submission versions in a future version of Central.
 
@@ -257,3 +273,56 @@ Finally, when edits are submitted, the submission :ref:`review state <central-su
 
 .. image:: /img/central-submissions/diff.png
 
+.. _central-offline-web-forms:
+
+Allowing web form users to work offline
+---------------------------------------
+
+.. note::
+
+   ODK Web Forms does not yet support offline use. If someone loses connectivity while filling out an ODK Web Forms form, they will be able to complete filling it out but will need an Internet connection before they can submit.
+
+Enketo's offlineable mode makes it possible to launch a form while offline, save drafts of that form, queue submissions to be sent to a server, and automatically send queued submissions once a connection is available.
+
+.. note::
+    Queued submissions are automatically sent **only if the form is open** in a browser when a connection is available.
+
+You can make an Enketo form offlineable by changing the form's web address and sharing that modified address. The way to do this depends on your Central version but links from older versions of Central will continue to work in newer versions.
+
+.. tab-set::
+
+  .. tab-item:: Central v2025.1.0+
+
+    **Offlineable link that does not require logging in**
+
+    #. Create a Public Access Link for your form. You can create a single shared link or repeat these instructions for each person filling out data so that you can track who is submitting.
+
+    #. Copy the link and paste it in a web browser.
+
+    #. Add ``/offline`` to the address right before the ``?st``.
+
+    #. Press ``Enter`` on your keyboard, confirm that you are redirected to a new address, and make sure that you see an orange connectivity icon in the upper left of the form.
+
+    #. Copy the link that you were redirected to and share it with your data collector(s).
+
+    **Offlineable link that requires logging in to submit**
+
+    #. Give the :guilabel:`Data Collector` role to any individual who will need to fill out this form.
+
+    #. Go to the form filling page for your form by clicking the :guilabel:`Add submission` button.
+
+    #. You should see your form and the web address should end with ``/new``. Add ``/offline`` to make the address end with ``/new/offline``.
+
+    #. Press ``Enter`` on your keyboard, confirm that you are redirected to a new address, and make sure that you see an orange connectivity icon in the upper left of the form.
+
+    #. Copy the link that you were redirected to and share it with your data collector(s). They will need to log in to first access the form and when they submit.
+
+  .. tab-item:: Central v2024.3.2 and prior
+
+    #. Go to a web form link by clicking the :guilabel:`New` button on the submissions page or by copying and pasting a :ref:`Public Access Link <central-submissions-public-link>`.
+
+    #. Add ``x/`` after ``/-/`` in the address. For :ref:`Public Access Links <central-submissions-public-link>`, replace ``single/`` with ``x/``.
+
+    #. Press ``Enter`` on your keyboard, and make sure that you see an orange connectivity icon in the upper left of the form.
+
+    #. Copy the link and share it with your data collector(s)

--- a/docs/central-submissions.rst
+++ b/docs/central-submissions.rst
@@ -23,6 +23,10 @@ ODK Central bundles `Enketo <https://enketo.org>`_ to enable editing, previewing
 
   Enketo does not always behave exactly like Collect, or support all the same features. The :doc:`XLSForm template <xlsform>` provides compatibility information and we recommend testing your form as you expect users to interact with it.
 
+.. tip::
+
+  The ODK team is working on ODK Web Forms which will eventually replace Enketo in Central. Starting in Central v2025.1.0, you can :doc:`try it out <web-forms-intro>`!
+
 Any authorized Web User may fill out a Form directly from the browser, as will be described in more detail below. Additionally, ODK Central offers Public Access Links which grant anybody in possession of the link the ability to submit to a Form on your server. You can control whether each respondent can submit more than once, and revoke access from any Link at any time. It is also possible to make Enketo web forms :ref:`usable while offline <central-offline-web-forms>`.
 
 .. _central-submissions-direct:
@@ -282,18 +286,18 @@ Allowing web form users to work offline
 
    ODK Web Forms does not yet support offline use. If someone loses connectivity while filling out an ODK Web Forms form, they will be able to complete filling it out but will need an Internet connection before they can submit.
 
-Enketo's offlineable mode makes it possible to launch a form while offline, save drafts of that form, queue submissions to be sent to a server, and automatically send queued submissions once a connection is available.
+Enketo's offline-capable mode makes it possible to launch a form while offline, save drafts of that form, queue submissions to be sent to a server, and automatically send queued submissions once a connection is available.
 
 .. note::
     Queued submissions are automatically sent **only if the form is open** in a browser when a connection is available.
 
-You can make an Enketo form offlineable by changing the form's web address and sharing that modified address. The way to do this depends on your Central version but links from older versions of Central will continue to work in newer versions.
+You can make an Enketo form offline-capable by changing the form's web address and sharing that modified address. The way to do this depends on your Central version but links from older versions of Central will continue to work in newer versions.
 
 .. tab-set::
 
   .. tab-item:: Central v2025.1.0+
 
-    **Offlineable link that does not require logging in**
+    **Offline-capable link that does not require logging in**
 
     #. Create a Public Access Link for your form. You can create a single shared link or repeat these instructions for each person filling out data so that you can track who is submitting.
 
@@ -305,7 +309,7 @@ You can make an Enketo form offlineable by changing the form's web address and s
 
     #. Copy the link that you were redirected to and share it with your data collector(s).
 
-    **Offlineable link that requires logging in to submit**
+    **Offline-capable link that requires logging in to submit**
 
     #. Give the :guilabel:`Data Collector` role to any individual who will need to fill out this form.
 

--- a/docs/form-logic.rst
+++ b/docs/form-logic.rst
@@ -890,7 +890,7 @@ The labels are also shown in the jump menu.
 Filtering options in select questions
 ===============================================
 
-To limit the options in a select or :doc:`rank <rank-widget>` question based on the answer to a previous question, specify an expression in the ``choice_filter`` column of the **survey** sheet. This choice filter expression must refer to one or more column in the **choices** sheet that the dataset should be filtered by.
+To limit the options in a select or :ref:`rank <rank-widget>` question based on the answer to a previous question, specify an expression in the ``choice_filter`` column of the **survey** sheet. This choice filter expression must refer to one or more column in the **choices** sheet that the dataset should be filtered by.
 
 For example, you might ask your enumerators to select a state first, and then only display cities within that state. This is referred to as a "cascading select" and can be extended to any depth. The example below has two levels: job category and job title.
 

--- a/docs/img/web-forms/calendar-yyyy-mm-dd.png
+++ b/docs/img/web-forms/calendar-yyyy-mm-dd.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:951efcb5ba4f2bdb0b34cfee89afa686016b5bdfa06446f6c32ded87db2efcdb
+size 153138

--- a/docs/img/web-forms/geopoint-permission.png
+++ b/docs/img/web-forms/geopoint-permission.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d31473531a1b64efdc7b5a309b7e9a835d05821b49ac952f95166c7f992fae1b
+size 263697

--- a/docs/img/web-forms/geopoint-permission.png
+++ b/docs/img/web-forms/geopoint-permission.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d31473531a1b64efdc7b5a309b7e9a835d05821b49ac952f95166c7f992fae1b
-size 263697
+oid sha256:aa0045621fcaf2551b46ccea4ee45c6734b25c128102aa574871a0f20b17460e
+size 509880

--- a/docs/img/web-forms/geopoint-refining-accuracy.png
+++ b/docs/img/web-forms/geopoint-refining-accuracy.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0774e977fc1311e56716fc2ee54ba62c146de92d7cee6e04e6411c8074bcbc7b
-size 56237
+oid sha256:3f9d8dbc7cd1634df3a04fdfc22c9a324f31586a531eedee2c0e9b204fc12096
+size 193331

--- a/docs/img/web-forms/geopoint-refining-accuracy.png
+++ b/docs/img/web-forms/geopoint-refining-accuracy.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0774e977fc1311e56716fc2ee54ba62c146de92d7cee6e04e6411c8074bcbc7b
+size 56237

--- a/docs/img/web-forms/image-desktop.png
+++ b/docs/img/web-forms/image-desktop.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58b8d2d4e04e6d746b19862d0687e12f42c32c4cd5c0f6be14d0d8d8825888ae
+size 1530996

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -47,6 +47,7 @@ ODK is open-source software that's made by a welcoming community of people just 
   central-install
   central-using
   central-manage
+  web-forms-intro
   central-best-practices
 
 .. toctree::

--- a/docs/web-forms-intro.rst
+++ b/docs/web-forms-intro.rst
@@ -1,0 +1,70 @@
+Trying ODK Web Forms
+====================
+
+ODK Central provides a web-based interface to your forms for data edits, to preview form definitions, and to enable data collection from devices other than Android phones. You can learn more about :ref:`how Central uses web-based forms <central-web-submissions>`.
+
+By default, web forms in Central are powered by `Enketo <https://enketo.org/>`_, a powerful library that was initially developed outside the ODK project and that the ODK team has contributed to.
+
+The ODK team is now developing `ODK Web Forms <https://github.com/getodk/web-forms?tab=readme-ov-file#odk-web-forms>`_ which will eventually replace Enketo in ODK Central. ODK Web Forms is designed to align with ODK Collect and provide a modern user experience. This page describes how to opt into trying ODK Web Forms and documents its functionality.
+
+To quickly try your forms in ODK Web Forms, see `the preview website <https://getodk.org/web-forms-preview/>`_. This page describes how to :ref:`opt a Central Form into using ODK Web Forms <web-forms-opt-in>` for all web-based functions and documents :ref:`more complex question types <web-forms-question-types>`.
+
+.. _web-forms-opt-in:
+
+Opting into ODK Web Forms in Central
+----------------------------------------
+
+.. warning::
+    ODK Web Forms is experimental and does not support all form functionality! Please test your form carefully.
+
+Starting in Central v2025.1.0, you can opt individual forms into using `ODK Web Forms <https://github.com/getodk/web-forms?tab=readme-ov-file#odk-web-forms>`_, an experimental replacement for Enketo designed from the ground up to align with ODK Collect. ODK Web Forms is still early in its development. We recommend trying ODK Web Forms if:
+
+* You are curious about how web forms will evolve in Central.
+* You want to provide feedback and ideas `on the forum <https://forum.getodk.org/tag/odk-webforms>`_.
+* You have a form that doesn't work well with Enketo. For example, this could be because of the presentation of certain question types such as ``geopoint``, performance issues, or bugs in repeats.
+
+To opt into ODK Web Forms, go to the :guilabel:`Settings` tab for a specific form. In the :guilabel:`Web Forms` section, select the :guilabel:`ODK Web Forms` option, read the description, and confirm that you want to opt in.
+
+You can see what functionality is currently supported `on Github <https://github.com/getodk/web-forms?tab=readme-ov-file#feature-matrix>`_. In particular, please note that the following sometimes subtle features are not yet supported:
+
+* :ref:`Dynamic defaults <dynamic-defaults>` and the XLSForm ``trigger`` column
+* :ref:`Metadata questions <metadata>`
+* Entity creation or update
+* References to form fields in translated labels and hints (this works for single-language forms)
+
+You can change a form's setting between Enketo and Web Forms at any time. Any form links that users already have will continue to work and will reflect the setting on the server at the time that the user loads the form link.
+
+.. _web-forms-question-types:
+
+Question types
+--------------
+
+To know which question types are currently supported in Web Forms, see `the Github feature matrix <https://github.com/getodk/we
+b-forms?tab=readme-ov-file#feature-matrix>`_. While most supported functionality is very similar to Collect's, this section describes question types with more complex functionality or that differ from Collect.
+
+Geopoint
+~~~~~~~~
+
+The :ref:`geopoint question type <geopoint-widget>` without appearance captures the current location of the device. Currently, this is the only location experience provided by Web Forms, including for edits. In the future, there will be a map-based interface accessible by setting different ``appearance`` values. Additionally, it will be possible to use a map to view and edit a location captured by the default geopoint question type.
+
+When a form includes a geopoint question, users of the form will see a :guilabel:`Get location` button. When a user taps that button, a dialog will appear, showing the accuracy of the currently-available location or no value if location permissions are not granted yet. If location permissions are not granted yet, the user will also be asked to grant location permissions by their browser.
+
+.. image:: /img/web-forms/geopoint-permission.*
+  :alt: Web Forms location permissions request
+
+.. warning::
+  
+  Different browsers manage location permissions differently. Some may not prompt for the permission and may require users to go to their settings to grant location access.
+
+  If a user denies location permissions to a form, that permission will apply for all forms on that server and a user may need to go to browser settings to grant the permission.
+
+Once location permissions are granted to Web Forms, it will start reading location data from available sensors on the device. The current location accuracy will be displayed along with qualitative information about that accuracy to help guide the person filling out the form to get the highest accuracy point possible. Location will continue to update until the user taps the :guilabel:`Save location` button or the accuracy reaches the target accuracy defined by the form, whichever comes first. The target accuracy is the value in the "Location will be saved at N m" message.
+
+.. image:: /img/web-forms/geopoint-refining-accuracy.*
+  :alt: Web forms location-finding dialog
+  :class: central-partial-screen
+
+Image
+~~~~~~~~
+
+The :ref:`image question type <image-widget>` without appearance allows the user to capture an image. In Web Forms, if the user is on a mobile device, they can take a picture with their mobile camera. Devices like laptops that use a desktop browser will not show the capture button, even if they have a built-in camera.

--- a/docs/web-forms-intro.rst
+++ b/docs/web-forms-intro.rst
@@ -32,7 +32,7 @@ You can see what functionality is currently supported `on Github <https://github
 * Entity creation or update
 * References to form fields in translated labels and hints (this works for single-language forms)
 
-You can change a form's setting between Enketo and Web Forms at any time. Any form links that users already have will continue to work and will reflect the setting on the server at the time that the user loads the form link.
+You can change a form's setting between Enketo and Web Forms at any time. Any form links that users already have will continue to work and will reflect the setting on the server at the time that the user loads the form link. Existing submissions are not affected by switching between web forms libraries.
 
 .. _web-forms-question-types:
 
@@ -67,4 +67,9 @@ Once location permissions are granted to Web Forms, it will start reading locati
 Image
 ~~~~~~~~
 
-The :ref:`image question type <image-widget>` without appearance allows the user to capture an image. In Web Forms, if the user is on a mobile device, they can take a picture with their mobile camera. Devices like laptops that use a desktop browser will not show the capture button, even if they have a built-in camera.
+The :ref:`image question type <default-image-widget>` without appearance allows the user to capture an image. In Web Forms, if the user is on a mobile device, they can take a picture with their mobile camera. Devices like laptops that use a desktop browser will not show the capture button, even if they have a built-in camera.
+
+Date
+~~~~~
+
+The :ref:`date question type <default-date-widget>` without appearance allows the user to enter a date. The user can manually type a date in the text field in the mm/dd/yyyy format or click in the field to select a date from a calendar. To change the year, they can press on the current year at the top of the calendar. To change the month, they can use the navigation arrows or press on the current month at the top of the calendar. There are also buttons to clear the date or jump to today.

--- a/docs/web-forms-intro.rst
+++ b/docs/web-forms-intro.rst
@@ -1,7 +1,7 @@
 Trying ODK Web Forms
 ====================
 
-ODK Central provides a web-based interface to your forms for data edits, to preview form definitions, and to enable data collection from devices other than Android phones. You can learn more about :ref:`how Central uses web-based forms <central-web-submissions>`.
+ODK Central provides a web-based interface to your forms for data edits, to preview form definitions, and to enable data collection from devices other than Android phones. You can learn about how Central uses web-based forms in :ref:`the section on managing Submissions <central-web-submissions>`.
 
 By default, web forms in Central are powered by `Enketo <https://enketo.org/>`_, a powerful library that was initially developed outside the ODK project and that the ODK team has contributed to.
 
@@ -17,11 +17,14 @@ Opting into ODK Web Forms in Central
 .. warning::
     ODK Web Forms is experimental and does not support all form functionality! Please test your form carefully.
 
-Starting in Central v2025.1.0, you can opt individual forms into using `ODK Web Forms <https://github.com/getodk/web-forms?tab=readme-ov-file#odk-web-forms>`_, an experimental replacement for Enketo designed from the ground up to align with ODK Collect. ODK Web Forms is still early in its development. We recommend trying ODK Web Forms if:
+Starting in Central v2025.1, you can opt individual forms into using `ODK Web Forms <https://github.com/getodk/web-forms?tab=readme-ov-file#odk-web-forms>`_, an alternative to Enketo designed from the ground up to align with ODK Collect. ODK Web Forms is still early in its development. We recommend trying ODK Web Forms if:
 
 * You are curious about how web forms will evolve in Central.
+* You like ODK Web Form's look and feel.
 * You want to provide feedback and ideas `on the forum <https://forum.getodk.org/tag/odk-webforms>`_.
 * You have a form that doesn't work well with Enketo. For example, this could be because of the presentation of certain question types such as ``geopoint``, performance issues, or bugs in repeats.
+
+If you try your form draft, make some test submissions, and find that all of the functionality that you need is supported well, Web Forms can be used to collect real data.
 
 To opt into ODK Web Forms, go to the :guilabel:`Settings` tab for a specific form. In the :guilabel:`Web Forms` section, select the :guilabel:`ODK Web Forms` option, read the description, and confirm that you want to opt in.
 
@@ -62,14 +65,19 @@ Once location permissions are granted to Web Forms, it will start reading locati
 
 .. image:: /img/web-forms/geopoint-refining-accuracy.*
   :alt: Web forms location-finding dialog
-  :class: central-partial-screen
 
 Image
 ~~~~~~~~
+
+.. image:: /img/web-forms/image-desktop.*
+  :class: central-partial-screen
 
 The :ref:`image question type <default-image-widget>` without appearance allows the user to capture an image. In Web Forms, if the user is on a mobile device, they can take a picture with their mobile camera. Devices like laptops that use a desktop browser will not show the capture button, even if they have a built-in camera.
 
 Date
 ~~~~~
+
+.. image:: /img/web-forms/calendar-yyyy-mm-dd.*
+  :class: central-partial-screen
 
 The :ref:`date question type <default-date-widget>` without appearance allows the user to enter a date. The user can manually type a date in the text field in the mm/dd/yyyy format or click in the field to select a date from a calendar. To change the year, they can press on the current year at the top of the calendar. To change the month, they can use the navigation arrows or press on the current month at the top of the calendar. There are also buttons to clear the date or jump to today.

--- a/docs/web-forms-intro.rst
+++ b/docs/web-forms-intro.rst
@@ -1,3 +1,6 @@
+.. spelling:word-list::
+    yyyy
+
 Trying ODK Web Forms
 ====================
 


### PR DESCRIPTION
Adds a new "Trying ODK Web Forms" page. I'm open to alternative title suggestions. I wanted to make it intriguing and clear that it's experimental. I also wanted to avoid confusion with generic "web forms".

I originally had tried doing a page about generic "web forms" that combined information about Enketo and Web Forms. I got good feedback around that not being future-looking enough so I reworked it to be more focused.

See it at https://output.circle-artifacts.com/output/job/b30c0002-30c3-448f-82aa-98f5b84384d3/artifacts/0/docs/_build/dirhtml/web-forms-intro/index.html and https://output.circle-artifacts.com/output/job/dbef5880-2359-4960-b034-093dbc0d3439/artifacts/0/docs/_build/dirhtml/central-submissions/index.html

Screenshots are placeholders for now to show the general structure of the page, @alyblenkin will work on more beautiful ones!