### PR TITLE
Check in CircleCI that Git LFS was used

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,13 @@ jobs:
           name: Checkout binaries
           command: git lfs pull
       - run:
+          name: Check that Git LFS was used to commit binaries
+          command: |
+            git ls-files | git check-attr --stdin filter | \
+              awk -F': ' '$3 ~ /lfs/ { print $1}' | \
+              xargs -L1 sh -c 'git cat-file blob "HEAD:$0" | \
+              git lfs pointer --check --stdin || { echo "$0"; false; }'
+      - run:
           name: Install build requirements
           command: |
             sudo apt-get install pngquant


### PR DESCRIPTION
Some Git operations can be difficult when Git LFS is in use and some files aren't pointers when they are expected to be. For example, when I use Git locally on the current `master` branch, I see that the working directory is not clean. Yet `git reset --hard` doesn't fix it:

```
$ git status
On branch master
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   docs/img/form-datasets/instances.png
	modified:   docs/img/form-datasets/lookup-expression.png

no changes added to commit (use "git add" and/or "git commit -a")

$ git reset --hard
HEAD is now at 85a432e Update API docs for v2025.1 (#1948)
Encountered 2 files that should have been pointers, but weren't:
	docs/img/form-datasets/instances.png
	docs/img/form-datasets/lookup-expression.png

$ git status
On branch master
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   docs/img/form-datasets/instances.png
	modified:   docs/img/form-datasets/lookup-expression.png
```

Modified files can also make it difficult to `git switch`, `git pull`, or `git stash`.

#1949 fixes the situation on `master` by tracking the two files above. This PR updates the CircleCI config to check for such files going forward. If there is such a file in a new PR, CircleCI will fail for the PR.

I just copied the Bash command from #1949. I'm not sure my Bash skills are quite at the level where I understand 100% what the command is doing, but I think I understand it at least at a high level. If @lognaturel feels good about the command, I think we can run with it. It's just being run in CircleCI.

This PR intentionally fails in CircleCI in order to give an example of how it works. Once #1949 is merged into `master`, I'll merge `master` into this branch, then CircleCI should pass.