### PR TITLE
digital-ocean/postgres: clarify extensions documentation

### DIFF
--- a/docs/central-install-digital-ocean.rst
+++ b/docs/central-install-digital-ocean.rst
@@ -480,7 +480,7 @@ Central comes with a PostgreSQL v14.x database server to store your data. To use
       CREATE USER mydbuser WITH PASSWORD 'mydbpassword';
       CREATE DATABASE mydbname WITH OWNER=mydbuser ENCODING=UTF8;
 
-#. Ensure ``CITEXT`` and ``pg_trgm`` extensions exist on `mydbname`.
+#. Ensure the required PostgreSQL extensions exist on `mydbname`.
 
    .. code-block:: postgres
 


### PR DESCRIPTION
Avoid repeating extension names in descriptive text.  This removes ambiguity and the need to update this description every time the list of extensions changes.

Current docs can be seen at https://docs.getodk.org/central-install-digital-ocean/:

![Screenshot_2025-06-11_10-03-21](https://github.com/user-attachments/assets/7563f2f4-47c4-4ca8-a2a3-9900014c5c7d)

<!-- ALL PRs MUST BE RELATED TO AN OPEN ISSUE -->
closes #
<!-- OR -->
addresses #


#### What is included in this PR?

https://github.com/getodk/docs/pull/1959/files

<!-- Answer any that apply and delete the others. -->
#### What new issues will need to be opened because of this PR?

None, unless an issue is required as reference for this PR.

#### What is left to be done in the addressed issue?

Nothing that I know of.

#### What problems did you encounter?

None.