### PR TITLE
Remove suggestion that hash is MD5 of media file contents

### DIFF
--- a/docs/openrosa-form-list.rst
+++ b/docs/openrosa-form-list.rst
@@ -206,7 +206,7 @@ Elements within ``<mediaFile/>``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  ``<filename/>`` The unique un-rooted file path for this media file. This un-rooted path must not start with a drive name or slash and must not contain relative path navigations (for example, ``.`` or ``..``).
--  ``<hash/>`` The hash value of the media file available for download. The only hash values currently supported are MD5 hashes of the file contents; they are prefixed by ``md5:``. If the hash value identified in the manifest differs from the hash value for a previously-downloaded media file, then the file should be re-fetched from the server.
+-  ``<hash/>`` The only hash values currently supported are MD5 hashes of the file contents; they are prefixed by md5:. If the hash value identified in the manifest differs from the hash value when the media file was previously downloaded, then the file should be re-fetched from the server.
 -  ``<downloadUrl/>`` A fully qualified URI for downloading the media file to the device. It may be a valid http or https URI of any structure; the server may require authentication; the server may require a secure (https) channel, etc.
 -  ``<integrityUrl/>`` A fully qualified URI for using the :doc:`Integrity API <openrosa-integrity>` for this media file. This is optional, but must be present if the media file has the ``type`` attribute with the value ``entityList``.
 


### PR DESCRIPTION
Work towards https://github.com/getodk/collect/issues/6768


#### What is included in this PR?

This just (hopefully) clarifies that the media file hash does have to represent the contents of the media file itself.
