### PR TITLE
Change bot protection to one that works better in poor connections

### DIFF
--- a/docs/_static/js/custom.js
+++ b/docs/_static/js/custom.js
@@ -13,6 +13,7 @@ document.addEventListener("DOMContentLoaded", function () {
   script.setAttribute("data-search-mode-default", false);
   script.setAttribute("data-search-include-source-names",'["Docs"]');
   script.setAttribute("data-modal-override-open-id", "custom-ask-ai-button");
+  script.setAttribute("data-bot-protection-mechanism", "hcaptcha");
   script.async = true;
   document.head.appendChild(script);
 });


### PR DESCRIPTION
From Kapa's support...

> From looking at the logs I can see that kapa is refusing to answer the user's question because the bot detection mechanism that's used on the widget is flagging the request as possible bot activity. I'm not sure what the exact reason is for this flag – it's usually caused by a VPN or browser extension interfering with the environment, but looking at the forum thread that doesn't seem to apply here. It might be the networking/connectivity issues that's causing reCAPTCHA to incorrectly flag this.
> 
> The only thing that I can think of that might mitigate this would be to change the bot protection mechanism in the widget from Google reCAPTCHA (default) to hCaptcha. This change does not have any drawbacks - in fact, hCaptcha is generally a better solution but we can't make it the default due to backwards compatibility.