### PR TITLE
Add high-level decription of Web Forms choice images

### DIFF
--- a/docs/img/web-forms/select-with-images.png
+++ b/docs/img/web-forms/select-with-images.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:333a79cc5c85ca035b29ce96269ffbab9b9860a00569af768f5ba6fa952569cd
+size 135536

--- a/docs/web-forms-intro.rst
+++ b/docs/web-forms-intro.rst
@@ -84,3 +84,15 @@ Date
   :class: central-partial-screen
 
 The :ref:`date question type <default-date-widget>` without appearance allows the user to enter a date. The user can manually type a date in the text field in the mm/dd/yyyy format or click in the field to select a date from a calendar. To change the year, they can press on the current year at the top of the calendar. To change the month, they can use the navigation arrows or press on the current month at the top of the calendar. There are also buttons to clear the date or jump to today.
+
+Selects with images
+~~~~~~~~~~~~~~~~~~~
+
+When you specify :ref:`images for select options <image-options>`, Web Forms displays the options in containers to support visual processing and make selection easier.
+
+.. image:: /img/web-forms/select-with-images.*
+  :class: central-partial-screen
+
+By default, choices with images are displayed in a grid. Each choice container is given the same width and height and the number of columns is determined by the screen width (this is the same as the :ref:`columns appearance <select-columns-widget>`). Images are never distorted or scaled up but they may be scaled down. The maximum image height used is 300px. We recommend using a consistent size for all images and trying your form on the devices you plan to use for data collection.
+
+If you would like to display one choice with image per row, as is the default for Collect, you can use the :ref:`columns-1 appearance <select-columns-n-widget>`.

--- a/docs/web-forms-intro.rst
+++ b/docs/web-forms-intro.rst
@@ -91,8 +91,8 @@ Selects with images
 When you specify :ref:`images for select options <image-options>`, Web Forms displays the options in containers to support visual processing and make selection easier.
 
 .. image:: /img/web-forms/select-with-images.*
-  :class: central-partial-screen
+  :alt: Select with images in Web Forms
 
-By default, choices with images are displayed in a grid. Each choice container is given the same width and height and the number of columns is determined by the screen width (this is the same as the :ref:`columns appearance <select-columns-widget>`). Images are never distorted or scaled up but they may be scaled down. The maximum image height used is 300px. We recommend using a consistent size for all images and trying your form on the devices you plan to use for data collection.
+By default, choices with images are displayed in a grid. Each choice container is given the same width and height and the number of columns is determined by the screen width (this is the same as the :ref:`columns appearance <select-columns-widget>`). Images are never distorted or scaled up but they may be scaled down. The maximum image height used is 300 pixels. We recommend using a consistent size for all images and trying your form on the devices you plan to use for data collection.
 
 If you would like to display one choice with image per row, as is the default for Collect, you can use the :ref:`columns-1 appearance <select-columns-n-widget>`.


### PR DESCRIPTION
Closes https://github.com/getodk/web-forms/issues/501

[See it in action](https://output.circle-artifacts.com/output/job/e163d562-9122-4624-983d-429aa5197882/artifacts/0/docs/_build/dirhtml/web-forms-intro/index.html#selects-with-images)

I described what I remember of the image resizing and quickly double-checked against https://github.com/getodk/web-forms/issues/347 and the all widgets form. It's worth a double check!