### PR TITLE
Add tips for image styling

### DIFF
--- a/docs/form-question-types.rst
+++ b/docs/form-question-types.rst
@@ -1317,7 +1317,7 @@ To make an image with selectable regions:
 Including media files in choices
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-As with questions themselves, choices can include :ref:`media <media>` (image, video, or audio files):
+Like :ref:`question labels <media>`, choices can include media (image, video, or audio files):
 
 .. csv-table:: choices
   :header: list_name, name, label, image, video, audio
@@ -1326,11 +1326,11 @@ As with questions themselves, choices can include :ref:`media <media>` (image, v
   opt_media,b,B,,b.mp4
   opt_media,c,C,,,c.mp3
 
-.. seealso:: 
-
-  For images, you can :ref:`specify a bigger image for panning and zooming <big-image>` using the ``big-image`` column. This is not compatible with the ``no-buttons`` appearance.
+.. seealso:: :ref:`Best practices for images <label-images-best-practices>` and :ref:`selects with images in Web Forms <web-forms-selects-images>`
 
 .. note::
+
+  For images, you can :ref:`specify a bigger image for panning and zooming <big-image>` using the ``big-image`` column. This is not compatible with the ``no-buttons`` appearance.
 
   ``select_one`` and ``select_multiple`` questions using the ``no-buttons`` appearances will not
   display media buttons next to choices. However, if a choice has audio, it will be played when

--- a/docs/form-styling.rst
+++ b/docs/form-styling.rst
@@ -17,10 +17,13 @@ can all be styled using
 Media
 ------
 
-A question label may include an image, an audio file and/or a video using the ``image``, ``audio`` and/or ``video`` columns.
-Files referenced should be included :ref:`in your form's media folder <loading-form-media>`.
+Images, audio and video can help make your forms more accessible, especially for enumerators or participants with lower literacy. Question labels can include any combination of images, audio and video in addition to text. You can also specify media for :ref:`select choices <image-options>`.
 
-.. seealso:: Media can be :doc:`translated <form-language>` or :ref:`used with select choices <image-options>`.
+To specify media for a question label, use the ``image``, ``audio`` and/or ``video`` columns on the ``survey`` sheet of your :doc:`xlsform`. When a form definition includes media, Central automatically detects which files are needed and :ref:`prompts you to attach them <central-forms-attachments>`. In Collect, files are stored :ref:`in your form's media folder <loading-form-media>`.
+
+.. seealso:: Media can be :doc:`translated <form-language>` or :ref:`used for select choices <image-options>`.
+
+.. _media-images:
 
 Images
 ~~~~~~~~
@@ -58,6 +61,72 @@ If your image is large or you would like to provide an alternative image with mo
   :header: type, name, label, image, big-image
 
   note, instructions, Go to the spot marked by an X. Tap the map to make it bigger., map-small.jpg, map-big.jpg
+
+.. _label-images-best-practices:
+
+Best practices for images
+""""""""""""""""""""""""""
+
+.. seealso:: :ref:`Using images for select choices <image-options>` and :ref:`selects with images in Web Forms <web-forms-selects-images>`
+
+Images can make forms easier to use and more engaging. Follow these tips to create images that enhance clarity and usability.
+
+**Tip 1: Use cohesive images to reduce cognitive load**
+
+* Make all images the same size (e.g. 300 x 300 pixels)
+* Use images with similar colors and contrast
+* Center the subject with equal whitespace around it
+* Keep backgrounds simple and uncluttered
+
+.. image:: /img/form-styling/label-images-cohesive.*
+  :alt: Examples of how to use images in selects. The good example has images on a white background. The bad example uses images with the subject cropped.
+
+**Tip 2: Use icons to simplify visuals**
+
+* Use open source libraries to find a cohesive set of icons (more details below)
+* Ensure the icons are large enough to recognize and understand
+* Pick distinct icons so users can tell them apart
+* Use icons with high color contrast and test in both light and dark modes
+
+.. image:: /img/form-styling/label-images-icons.*
+  :alt: Examples of how to use icons in selects. User friendly example includes consistent dark blue icons and the bad example uses low contrast icons and different sizes.
+
+**Tip 3: For images in choices, test column layouts with real users**
+
+* Get feedback on how many columns feel comfortable to view and tap
+* Consider smaller screens — more than two columns can feel crowded
+* Showing too many choices at once `can overwhelm users <https://lawsofux.com/choice-overload/>`_
+* If using multiple columns, icons need to be recognizable at a small scale
+* Keep labels short and specific to prevent awkward wrapping
+
+.. _label-images-icon-library:
+
+Using an icon library
+""""""""""""""""""""""
+
+If you don't have your own icon set, there are lots of great open-source options. Using icons from the same library, with the same style and weight, will make a better user experience. If one icon is big and bold in comparison to the others, it will slow down the user's decision making process because irregularity increases effort to make decisions (`Hick's Law <https://lawsofux.com/hicks-law/>`_).
+
+**Icon libraries**:
+
+* `Phosphor icons <https://phosphoricons.com/>`_
+* `Google icons <https://fonts.google.com/icons>`_
+* `Health icons <https://healthicons.org/>`_
+* `Pictogrammers <https://pictogrammers.com/library/mdi/>`_ (extension of the Google icons above)
+
+Once you've downloaded an icon that you want to use, you may want to add some white space around it so the icon doesn't look crowded with the screen edges or other content. One way to do this is by making a copy of `our icon template in Google Draw <https://docs.google.com/drawings/d/1fMdC8ZgSIpsNpl9grXr_6YQ9MZHvUn5Wr-4JnetJYok/edit>`_. Replace the image with each of your your downloaded icons and export the images with padding.
+
+You could also use a design tool like `Figma <https://www.figma.com/community/icons?resource_type=mixed&editor_type=all&price=all&sort_by=all_time&creators=all>`_ or `Canva's icon maker <https://www.canva.com/create/icons/>`_ to create equal spacing around your icon or create your own.
+
+.. _label-images-accessible:
+
+Making images accessible
+""""""""""""""""""""""""""
+
+Whether you're using images or icons, you should generally supplement them with brief written text in the ``label`` or ``hint``. When designing that text:
+
+* Avoid writing "Image or picture of"
+* Keep it short and specific
+* Focus on the details
 
 Audio
 ~~~~~~~~

--- a/docs/img/form-styling/label-images-cohesive.jpg
+++ b/docs/img/form-styling/label-images-cohesive.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c74d913b98461a2c25992a007d82c70f496d487e2970d4eabdb04c26bfba9b9e
+size 76018

--- a/docs/img/form-styling/label-images-icons.jpg
+++ b/docs/img/form-styling/label-images-icons.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf7c29288ba40ed3ff3f6416f19965c40060328ee4ab0e4ead4d8bf8789c1483
+size 62676

--- a/docs/web-forms-intro.rst
+++ b/docs/web-forms-intro.rst
@@ -85,8 +85,12 @@ Date
 
 The :ref:`date question type <default-date-widget>` without appearance allows the user to enter a date. The user can manually type a date in the text field in the mm/dd/yyyy format or click in the field to select a date from a calendar. To change the year, they can press on the current year at the top of the calendar. To change the month, they can use the navigation arrows or press on the current month at the top of the calendar. There are also buttons to clear the date or jump to today.
 
+.. _web-forms-selects-images:
+
 Selects with images
 ~~~~~~~~~~~~~~~~~~~
+
+.. seealso:: :ref:`Best practices for images <label-images-best-practices>`
 
 When you specify :ref:`images for select options <image-options>`, Web Forms displays the options in containers to support visual processing and make selection easier.
 


### PR DESCRIPTION
Inserts [tips for images](https://forum.getodk.org/t/form-design-tips-for-selects-with-images/55146) into the docs. I changed the tips just a little bit to apply more broadly to all form images so it could go in the form styling section. I cross linked with the new WF select with images section and the form design choices with media section.

See it in action