### PR TITLE
Add warning about S3 outages affecting form downloads

### DIFF
--- a/docs/central-install-digital-ocean.rst
+++ b/docs/central-install-digital-ocean.rst
@@ -534,8 +534,8 @@ Using S3-compatible Storage
 
 By default, Central stores form and submission attachments in its main database, but it can be configured to move these to an external object store. 
 
-**Important**: If your S3-compatible storage is unavailable, Central can continue accepting submissions, but devices may not be able to download new forms or attachments stored there.
-
+- If S3-compatible storage goes down, Central will still accept submissions, but devices may not receive updates to forms with attachments, and integrations or dashboards that use attachments may fail.
+- If you opt into S3-compatible storage, you must design a backup and restore strategy for that storage.
 If you already have or plan to collect many files, storing them outside the main database can reduce database load and cost. It can also make it more practical to backup and restore the database.
 
 Consider the following to help you decide whether S3-compatible storage is a good fit:

--- a/docs/central-install-digital-ocean.rst
+++ b/docs/central-install-digital-ocean.rst
@@ -532,7 +532,11 @@ Creating and using a custom PostgreSQL database server
 Using S3-compatible Storage
 ---------------------------
 
-By default, Central stores form and submission attachments in its main database, but it can be configured to move these to an external object store. If you already have or plan to collect many files, storing them outside the main database can reduce database load and cost. It can also make it more practical to backup and restore the database.
+By default, Central stores form and submission attachments in its main database, but it can be configured to move these to an external object store. 
+
+**Important**: If your S3-compatible storage is unavailable, Central can continue accepting submissions, but devices may not be able to download new forms or attachments stored there.
+
+If you already have or plan to collect many files, storing them outside the main database can reduce database load and cost. It can also make it more practical to backup and restore the database.
 
 Consider the following to help you decide whether S3-compatible storage is a good fit:
 

--- a/docs/entities-intro.rst
+++ b/docs/entities-intro.rst
@@ -27,7 +27,7 @@ Concepts
 What are Entities?
 ------------------
 
-In the ODK context, an "Entity" can be thought of as a "thing". If your project involves things that need to be shared between forms and may change over time, you can represent them as Entities. You can use Entities to represent real things like trees, people, or cities. You can also represent more abstract things like tree visits, malaria cases, or city ratings as Entities.
+In ODK, an **Entity** can be thought of as a “thing.” If your project involves items that need to be shared across forms and may change over time, you can represent them as Entities. Entities can represent real-world things such as trees, people, or cities. They can also represent more abstract concepts, such as tree visits, malaria cases, or city ratings.
 
 Entities are organized in lists that group together Entities of the same type. You can think of Entity Lists as spreadsheets or databases that are shared across forms. Forms can create, read, and update Entities. You can also think of Entities as the nouns (trees) and the forms as the verbs (Register a tree).
 

--- a/docs/entities-intro.rst
+++ b/docs/entities-intro.rst
@@ -27,7 +27,7 @@ Concepts
 What are Entities?
 ------------------
 
-In ODK, an **Entity** can be thought of as a “thing.” If your project involves items that need to be shared across forms and may change over time, you can represent them as Entities. Entities can represent real-world things such as trees, people, or cities. They can also represent more abstract concepts, such as tree visits, malaria cases, or city ratings.
+In the ODK context, an "Entity" can be thought of as a "thing". If your project involves things that need to be shared between forms and may change over time, you can represent them as Entities. You can use Entities to represent real things like trees, people, or cities. You can also represent more abstract things like tree visits, malaria cases, or city ratings as Entities.
 
 Entities are organized in lists that group together Entities of the same type. You can think of Entity Lists as spreadsheets or databases that are shared across forms. Forms can create, read, and update Entities. You can also think of Entities as the nouns (trees) and the forms as the verbs (Register a tree).
 


### PR DESCRIPTION
#### What is included in this PR?

Adds a warning to the S3 documentation explaining that an S3 outage can prevent devices from downloading new forms and attachments, even though Central can continue accepting submissions.

Fixes #2055