### PR TITLE
chore: clarify last-saved feature for encrypted forms

### DIFF
--- a/docs/central-encryption.rst
+++ b/docs/central-encryption.rst
@@ -27,6 +27,7 @@ However, here are some things that encryption will **not** do:
  - Prevent a hijacker from replacing forms or redirecting submissions to a malicious server.
  - Prevent the creation of phony submissions.
  - Substitute for HTTPS security on the web administration panel.
+ - Encrypt the values that :ref:`the last-saved feature <last-saved>` stores on the device or in the browser. Submissions are still encrypted as usual.
 
 And, here are some limitations that will appear when encryption is enabled on a project or form:
 

--- a/docs/encrypted-forms.rst
+++ b/docs/encrypted-forms.rst
@@ -45,6 +45,10 @@ In :doc:`XLSForm <xlsform>`, form encryption is enabled from the :ref:`settings 
 
   my_form, 2024050301, https://my-server/submission, MIIBIjANB...JCwIDAQAB
 
+.. warning::
+
+  If your form uses :ref:`values from the last saved record <last-saved>`, those values are stored **unencrypted** on the device (or in the browser for ODK Web Forms), even if you have set up encryption. Submissions are still encrypted as usual.
+
 .. _create-RSA-key:
 
 Creating RSA Key pair

--- a/docs/form-logic.rst
+++ b/docs/form-logic.rst
@@ -198,9 +198,9 @@ Values from the last saved record
 
   When this feature is used the full content of the last submitted form will be stored on the submitter's device indefinitely, therefore we do not recommend using this feature for forms that could contain sensitive information.
 
-  The last-saved feature does not work with encrypted forms.
+  This stored content is **not** encrypted, even if you have set up :ref:`encryption <encrypted-forms>` for your form. Submissions are still encrypted as usual. This is true in both ODK Collect and ODK Web Forms.
 
-  Support for last-saved was added in Collect v1.21.0 and Central v1.3.0. Using older versions or encrypted forms will have unpredictable results.
+  Support for last-saved was added in Collect v1.21.0 and Central v1.3.0. Using older versions will have unpredictable results.
 
 You can refer to values from the last saved record of this form definition:
 


### PR DESCRIPTION
#### What is included in this PR?

Last-saved values are not encrypted; adds that info in the docs. 

<!-- Answer any that apply and delete the others. -->
#### What new issues will need to be opened because of this PR?

none

#### What is left to be done in the addressed issue?

none

#### What problems did you encounter?

none
